### PR TITLE
feat: add NeoForge 1.21.1 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,52 +1,56 @@
 plugins {
 	id 'java'
 	id 'eclipse'
-	id 'net.minecraftforge.gradle' version '[6.0.16,6.2)'
+	id 'net.neoforged.moddev' version '2.0.141'
 	id 'me.hypherionmc.cursegradle' version '2.+'
 }
 
-archivesBaseName = "${mod_name}-${minecraft_version}"
+archivesBaseName = "${mod_name}-${minecraft_version}-neoforge"
 version = mod_version
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + ' (' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
-minecraft {
-	mappings channel: 'official', version: minecraft_version
-	accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+neoForge {
+	version = neo_version
+	accessTransformers = project.files('src/main/resources/META-INF/accesstransformer.cfg')
 	
 	runs {
-		configureEach {
-			workingDirectory project.file('run')
-		}
-		
 		client {
-			taskName "${project.name}Client"
+			client()
+			gameDirectory = project.file('run')
+			systemProperty 'neoforge.enabledGameTestNamespaces', mod_id
 		}
 		
 		server {
-			taskName "${project.name}Server"
+			server()
+			gameDirectory = project.file('run')
+			programArgument '--nogui'
+			systemProperty 'neoforge.enabledGameTestNamespaces', mod_id
 		}
 		
 		gameTestServer {
-			taskName "${project.name}GameTest"
-			property 'forge.enabledGameTestNamespaces', mod_id
+			type = "gameTestServer"
+			gameDirectory = project.file('run')
+			systemProperty 'neoforge.enabledGameTestNamespaces', mod_id
 		}
 		
 		data {
-			workingDirectory project.file('run-data')
-			taskName "${project.name}Data"
-			args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+			data()
+			gameDirectory = project.file('run-data')
+			programArguments.addAll '--mod', mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
+		}
+	}
+	
+	mods {
+		"${mod_id}" {
+			sourceSet(sourceSets.main)
 		}
 	}
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
-
-dependencies {
-	minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-}
 
 tasks.named('jar', Jar).configure {
 	manifest {
@@ -70,9 +74,9 @@ tasks.named('processResources', ProcessResources).configure {
 	
 	from sourceSets.main.resources
 	
-    filesMatching(['META-INF/mods.toml']) {
-        expand project.properties
-    }
+	filesMatching(['META-INF/neoforge.mods.toml']) {
+		expand project.properties
+	}
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -86,16 +90,15 @@ curseforge {
 		changelog = file('changelog.txt').canRead() ? file('changelog.txt').text : ''
 		changelogType = 'text'
 		releaseType = 'release'
-		addGameVersion 'Forge'
-		forge_compatible_minecraft_versions.split(",").each {
+		addGameVersion 'NeoForge'
+		neoforge_compatible_minecraft_versions.split(",").each {
 			addGameVersion(it)
 		}
 		mainArtifact(jar) {
-			displayName = "${minecraft_version}-${mod_version} Universal"
+			displayName = "${minecraft_version}-${mod_version} NeoForge"
 		}
 	}
 	options {
 		javaVersionAutoDetect = false
-		forgeGradleIntegration = false
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ author = Exopandora
 # NeoForge
 neo_version = 21.1.225
 loader_version_range = [4,)
-neoforge_compatible_minecraft_versions = 1.21.1
+neoforge_compatible_minecraft_versions = 1.21,1.21.1
 
 # Publishing
 curse_project_id = 228970

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,16 @@
 # WorldHandler
 mod_id = worldhandler
 mod_name = WorldHandler
-mod_version = 3.5.1
-minecraft_version = 1.20.4
+mod_version = 3.5.2-neoforge
+minecraft_version = 1.21.1
 group = exopandora.worldhandler
 main_class = exopandora.worldhandler.Main
 author = Exopandora
 
-# Forge
-forge_version = 49.0.3
-forge_compatible_minecraft_versions = 1.20.3,1.20.4
+# NeoForge
+neo_version = 21.1.225
+loader_version_range = [4,)
+neoforge_compatible_minecraft_versions = 1.21.1
 
 # Publishing
 curse_project_id = 228970

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,14 +2,14 @@ pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		maven {
-			name = 'MinecraftForge'
-			url = 'https://maven.minecraftforge.net/'
+			name = 'NeoForge'
+			url = 'https://maven.neoforged.net/releases'
 		}
 	}
 }
 
 plugins {
-	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'WorldHandler'

--- a/src/main/java/exopandora/worldhandler/WorldHandler.java
+++ b/src/main/java/exopandora/worldhandler/WorldHandler.java
@@ -11,25 +11,20 @@ import exopandora.worldhandler.event.KeyHandler;
 import exopandora.worldhandler.gui.category.Category;
 import exopandora.worldhandler.gui.content.Content;
 import exopandora.worldhandler.usercontent.UsercontentLoader;
-import exopandora.worldhandler.util.AdvancementHelper;
 import exopandora.worldhandler.util.CommandHelper;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterClientCommandsEvent;
-import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
-import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.DistExecutor.SafeRunnable;
-import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
-import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.config.ModConfig.Type;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.loading.FMLPaths;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig.Type;
+import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.fml.loading.FMLPaths;
 
 @Mod(Main.MODID)
 public class WorldHandler
@@ -37,27 +32,19 @@ public class WorldHandler
 	public static final Logger LOGGER = LogManager.getLogger();
 	public static final Path USERCONTENT_PATH = FMLPaths.CONFIGDIR.get().resolve(Main.MODID).resolve("usercontent");
 	
-	public WorldHandler()
+	public WorldHandler(IEventBus modEventBus, ModContainer modContainer)
 	{
-		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-		ModLoadingContext modLoadingContext = ModLoadingContext.get();
-		DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> new SafeRunnable()
+		if(Dist.CLIENT.equals(FMLEnvironment.dist))
 		{
-			@Override
-			public void run()
-			{
-				Config.setupDirectories(WorldHandler.USERCONTENT_PATH);
-				modLoadingContext.registerConfig(Type.CLIENT, Config.CLIENT_SPEC, Main.MODID + "/" + Main.MODID + ".toml");
-				UsercontentLoader.load(WorldHandler.USERCONTENT_PATH);
-				modEventBus.addListener(WorldHandler.this::registerKeyMappingsEvent);
-				modEventBus.addListener(WorldHandler.this::registerClientReloadListeners);
-				modEventBus.addListener(Content::createRegistry);
-				modEventBus.addListener(Category::createRegistry);
-				modEventBus.addListener(Content::register);
-				modEventBus.addListener(Category::register);
-			}
-		});
-		modLoadingContext.registerExtensionPoint(DisplayTest.class, () -> new DisplayTest(() -> "ANY", (remote, isServer) -> true));
+			Config.setupDirectories(WorldHandler.USERCONTENT_PATH);
+			modContainer.registerConfig(Type.CLIENT, Config.CLIENT_SPEC, Main.MODID + "/" + Main.MODID + ".toml");
+			UsercontentLoader.load(WorldHandler.USERCONTENT_PATH);
+			modEventBus.addListener(WorldHandler.this::registerKeyMappingsEvent);
+			modEventBus.addListener(Content::createRegistry);
+			modEventBus.addListener(Category::createRegistry);
+			modEventBus.addListener(Content::register);
+			modEventBus.addListener(Category::register);
+		}
 		modEventBus.addListener(this::clientSetup);
 		modEventBus.addListener(this::commonSetup);
 	}
@@ -65,15 +52,15 @@ public class WorldHandler
 	@SubscribeEvent
 	public void clientSetup(FMLClientSetupEvent event)
 	{
-		MinecraftForge.EVENT_BUS.addListener(KeyHandler::keyInputEvent);
-		MinecraftForge.EVENT_BUS.addListener(ClientEventHandler::renderLevelStageEvent);
-		MinecraftForge.EVENT_BUS.addListener(ClientEventHandler::clientTickEvent);
+		NeoForge.EVENT_BUS.addListener(KeyHandler::keyInputEvent);
+		NeoForge.EVENT_BUS.addListener(ClientEventHandler::renderLevelStageEvent);
+		NeoForge.EVENT_BUS.addListener(ClientEventHandler::clientTickEvent);
 	}
 	
 	@SubscribeEvent
 	public void commonSetup(FMLCommonSetupEvent event)
 	{
-		MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
+		NeoForge.EVENT_BUS.addListener(this::registerCommands);
 	}
 	
 	@SubscribeEvent
@@ -88,11 +75,5 @@ public class WorldHandler
 	public void registerCommands(RegisterClientCommandsEvent event)
 	{
 		CommandHelper.registerCommands(event.getDispatcher(), event.getBuildContext());
-	}
-	
-	@SubscribeEvent
-	public void registerClientReloadListeners(RegisterClientReloadListenersEvent event)
-	{
-		event.registerReloadListener(AdvancementHelper.getInstance());
 	}
 }

--- a/src/main/java/exopandora/worldhandler/builder/argument/Arguments.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/Arguments.java
@@ -1,6 +1,7 @@
 package exopandora.worldhandler.builder.argument;
 
 import java.util.function.Function;
+import java.util.Locale;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -15,7 +16,7 @@ import exopandora.worldhandler.builder.argument.PrimitiveArgument.Operation;
 import exopandora.worldhandler.builder.argument.PrimitiveArgument.Relation;
 import exopandora.worldhandler.builder.argument.PrimitiveArgument.Type;
 import exopandora.worldhandler.util.EnumHelper;
-import net.minecraft.Util;
+import exopandora.worldhandler.util.RegistryHelper;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.ParserUtils;
 import net.minecraft.commands.arguments.EntityAnchorArgument.Anchor;
@@ -160,7 +161,7 @@ public class Arguments
 	
 	public static PrimitiveArgument<ResourceLocation> resourceLocation()
 	{
-		return PrimitiveArgument.builder(string -> string.isEmpty() ? null : new ResourceLocation(string)).build();
+		return PrimitiveArgument.<ResourceLocation>builder(string -> string.isEmpty() ? null : ResourceLocation.parse(string)).build();
 	}
 	
 	public static ItemArgument item()
@@ -262,8 +263,8 @@ public class Arguments
 	
 	public static PrimitiveArgument<Anchor> anchor()
 	{
-		return PrimitiveArgument.builder(string -> EnumHelper.find(string, Anchor.values(), anchor -> anchor.name))
-				.serializer(anchor -> anchor.name)
+		return PrimitiveArgument.builder(Anchor::getByName)
+				.serializer(anchor -> anchor.name().toLowerCase(Locale.ROOT))
 				.build();
 	}
 	
@@ -292,13 +293,13 @@ public class Arguments
 		{
 			try
 			{
-				return Component.Serializer.fromJson(string);
+				return Component.Serializer.fromJson(string, RegistryHelper.registryAccess());
 			}
 			catch(Exception e)
 			{
 				return Component.literal(string);
 			}
-		}).serializer(Component.Serializer::toJson).build();
+		}).serializer(component -> Component.Serializer.toJson(component, RegistryHelper.registryAccess())).build();
 	}
 	
 	public static PrimitiveArgument<PrimitiveArgument.Relation> relation()
@@ -355,14 +356,14 @@ public class Arguments
 		{
 			try
 			{
-				return ParserUtils.parseJson(new StringReader(string), Style.Serializer.CODEC);
+				return ParserUtils.parseJson(RegistryHelper.registryAccess(), new StringReader(string), Style.Serializer.CODEC);
 			}
 			catch(Exception e)
 			{
 				return null;
 			}
 		})
-		.serializer(style -> GSON.toJson(Util.getOrThrow(Style.Serializer.CODEC.encodeStart(JsonOps.INSTANCE, style), JsonParseException::new)))
+		.serializer(style -> GSON.toJson(Style.Serializer.CODEC.encodeStart(JsonOps.INSTANCE, style).getOrThrow(JsonParseException::new)))
 		.build();
 	}
 }

--- a/src/main/java/exopandora/worldhandler/builder/argument/BlockPredicateArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/BlockPredicateArgument.java
@@ -16,7 +16,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class BlockPredicateArgument extends TagArgument
 {
@@ -38,7 +38,7 @@ public class BlockPredicateArgument extends TagArgument
 	{
 		if(state != null)
 		{
-			this.resource = ForgeRegistries.BLOCKS.getKey(state.getBlock());
+			this.resource = BuiltInRegistries.BLOCK.getKey(state.getBlock());
 			this.properties = propertiesToString(state.getValues());
 		}
 		else

--- a/src/main/java/exopandora/worldhandler/builder/argument/BlockStateArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/BlockStateArgument.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class BlockStateArgument extends TagArgument
 {
@@ -24,7 +24,7 @@ public class BlockStateArgument extends TagArgument
 	{
 		if(block != null)
 		{
-			this.set(ForgeRegistries.BLOCKS.getValue(block));
+			this.set(BuiltInRegistries.BLOCK.get(block));
 		}
 		else
 		{
@@ -104,7 +104,7 @@ public class BlockStateArgument extends TagArgument
 		
 		StringBuilder builder = new StringBuilder(this.state.toString());
 		String block = this.state.getBlock().toString();
-		builder.replace(0, block.length(), ForgeRegistries.BLOCKS.getKey(this.state.getBlock()).toString());
+		builder.replace(0, block.length(), BuiltInRegistries.BLOCK.getKey(this.state.getBlock()).toString());
 		String nbt = super.serialize();
 		
 		if(nbt != null && this.state.hasBlockEntity())

--- a/src/main/java/exopandora/worldhandler/builder/argument/EffectArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/EffectArgument.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 import exopandora.worldhandler.util.ResourceHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class EffectArgument implements IDeserializableArgument
 {
@@ -25,7 +25,7 @@ public class EffectArgument implements IDeserializableArgument
 	{
 		if(effect != null)
 		{
-			this.set(ForgeRegistries.MOB_EFFECTS.getValue(effect));
+			this.set(BuiltInRegistries.MOB_EFFECT.get(effect));
 		}
 		else
 		{
@@ -54,7 +54,7 @@ public class EffectArgument implements IDeserializableArgument
 			return null;
 		}
 		
-		return ForgeRegistries.MOB_EFFECTS.getKey(this.effect).toString();
+		return BuiltInRegistries.MOB_EFFECT.getKey(this.effect).toString();
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/builder/argument/EnchantmentArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/EnchantmentArgument.java
@@ -2,10 +2,10 @@ package exopandora.worldhandler.builder.argument;
 
 import javax.annotation.Nullable;
 
+import exopandora.worldhandler.util.RegistryHelper;
 import exopandora.worldhandler.util.ResourceHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class EnchantmentArgument implements IDeserializableArgument
 {
@@ -25,7 +25,7 @@ public class EnchantmentArgument implements IDeserializableArgument
 	{
 		if(enchantment != null)
 		{
-			this.set(ForgeRegistries.ENCHANTMENTS.getValue(enchantment));
+			this.set(RegistryHelper.getEnchantment(enchantment));
 		}
 		else
 		{
@@ -54,7 +54,7 @@ public class EnchantmentArgument implements IDeserializableArgument
 			return null;
 		}
 		
-		return ForgeRegistries.ENCHANTMENTS.getKey(this.enchantment).toString();
+		return RegistryHelper.getEnchantmentKey(this.enchantment).toString();
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/builder/argument/EntitySummonArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/EntitySummonArgument.java
@@ -10,38 +10,38 @@ import exopandora.worldhandler.util.ResourceHelper;
 import net.minecraft.Util;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class EntitySummonArgument implements IDeserializableArgument
 {
 	private static final Map<String, ResourceLocation> ALIASES = Util.make(new HashMap<String, ResourceLocation>(), map ->
 	{
-		map.put("RedCow", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.MOOSHROOM));
-		map.put("ChickenJockey", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.CHICKEN));
-		map.put("Pigman", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PIGLIN));
-		map.put("ZombiePig", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PIGLIN));
-		map.put("ZombiePigman", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PIGLIN));
-		map.put("Dog", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.WOLF));
-		map.put("Dragon", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.ENDER_DRAGON));
-		map.put("SnowMan", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.SNOW_GOLEM));
-		map.put("LavaCube", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.MAGMA_CUBE));
-		map.put("MagmaSlime", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.MAGMA_CUBE));
-		map.put("LavaSlime", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.MAGMA_CUBE));
-		map.put("SpiderJockey", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.SPIDER));
-		map.put("VillagerGolem", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.IRON_GOLEM));
-		map.put("Ozelot", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.OCELOT));
-		map.put("Kitty", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.CAT));
-		map.put("Kitten", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.CAT));
-		map.put("TESTIFICATE", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.VILLAGER));
-		map.put("Octopus", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.SQUID));
-		map.put("GlowingOctopus", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.SQUID));
-		map.put("Exwife", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.GHAST));
-		map.put("CommandMinecart", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.COMMAND_BLOCK_MINECART));
-		map.put("Wizard", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.EVOKER));
-		map.put("Johnny", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.VINDICATOR));
-		map.put("BabyZombie", ForgeRegistries.ENTITY_TYPES.getKey(EntityType.ZOMBIE));
+		map.put("RedCow", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.MOOSHROOM));
+		map.put("ChickenJockey", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.CHICKEN));
+		map.put("Pigman", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PIGLIN));
+		map.put("ZombiePig", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PIGLIN));
+		map.put("ZombiePigman", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PIGLIN));
+		map.put("Dog", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.WOLF));
+		map.put("Dragon", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ENDER_DRAGON));
+		map.put("SnowMan", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.SNOW_GOLEM));
+		map.put("LavaCube", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.MAGMA_CUBE));
+		map.put("MagmaSlime", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.MAGMA_CUBE));
+		map.put("LavaSlime", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.MAGMA_CUBE));
+		map.put("SpiderJockey", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.SPIDER));
+		map.put("VillagerGolem", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.IRON_GOLEM));
+		map.put("Ozelot", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.OCELOT));
+		map.put("Kitty", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.CAT));
+		map.put("Kitten", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.CAT));
+		map.put("TESTIFICATE", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.VILLAGER));
+		map.put("Octopus", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.SQUID));
+		map.put("GlowingOctopus", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.SQUID));
+		map.put("Exwife", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.GHAST));
+		map.put("CommandMinecart", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COMMAND_BLOCK_MINECART));
+		map.put("Wizard", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.EVOKER));
+		map.put("Johnny", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.VINDICATOR));
+		map.put("BabyZombie", BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE));
 		
-		ForgeRegistries.VILLAGER_PROFESSIONS.getEntries().stream().forEach(profession -> map.put(profession.getKey().location().getPath(), profession.getKey().location()));
+		BuiltInRegistries.VILLAGER_PROFESSION.entrySet().stream().forEach(profession -> map.put(profession.getKey().location().getPath(), profession.getKey().location()));
 	});
 	
 	private EntityType<?> entity;
@@ -67,10 +67,10 @@ public class EntitySummonArgument implements IDeserializableArgument
 	{
 		if(entity != null)
 		{
-			EntityType<?> type = ForgeRegistries.ENTITY_TYPES.getValue(entity);
-			ResourceLocation location = ForgeRegistries.ENTITY_TYPES.getKey(type);
+			EntityType<?> type = BuiltInRegistries.ENTITY_TYPE.get(entity);
+			ResourceLocation location = BuiltInRegistries.ENTITY_TYPE.getKey(type);
 			
-			if(!ForgeRegistries.ENTITY_TYPES.getDefaultKey().equals(location) || location.equals(entity))
+			if(!BuiltInRegistries.ENTITY_TYPE.getDefaultKey().equals(location) || location.equals(entity))
 			{
 				this.set(type);
 			}
@@ -124,7 +124,7 @@ public class EntitySummonArgument implements IDeserializableArgument
 			return null;
 		}
 		
-		return ForgeRegistries.ENTITY_TYPES.getKey(this.entity).toString();
+		return BuiltInRegistries.ENTITY_TYPE.getKey(this.entity).toString();
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/builder/argument/ItemArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/ItemArgument.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import exopandora.worldhandler.util.ItemPredicateParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ItemArgument extends TagArgument
 {
@@ -27,7 +27,7 @@ public class ItemArgument extends TagArgument
 	{
 		if(item != null)
 		{
-			this.set(ForgeRegistries.ITEMS.getValue(item));
+			this.set(BuiltInRegistries.ITEM.get(item));
 		}
 		else
 		{
@@ -85,10 +85,10 @@ public class ItemArgument extends TagArgument
 		
 		if(tag != null)
 		{
-			return ForgeRegistries.ITEMS.getKey(this.item).toString() + tag;
+			return BuiltInRegistries.ITEM.getKey(this.item).toString() + tag;
 		}
 		
-		return ForgeRegistries.ITEMS.getKey(this.item).toString();
+		return BuiltInRegistries.ITEM.getKey(this.item).toString();
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/builder/argument/ItemArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/ItemArgument.java
@@ -4,7 +4,14 @@ import javax.annotation.Nullable;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import exopandora.worldhandler.builder.argument.tag.IItemComponentProvider;
 import exopandora.worldhandler.util.ItemPredicateParser;
+import exopandora.worldhandler.util.RegistryHelper;
+import net.minecraft.commands.arguments.item.ItemInput;
+import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -12,6 +19,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 public class ItemArgument extends TagArgument
 {
 	private Item item;
+	private List<IItemComponentProvider> componentProviders;
 	
 	protected ItemArgument()
 	{
@@ -38,6 +46,16 @@ public class ItemArgument extends TagArgument
 	public Item getItem()
 	{
 		return this.item;
+	}
+
+	public void addComponentProvider(IItemComponentProvider provider)
+	{
+		if(this.componentProviders == null)
+		{
+			this.componentProviders = new ArrayList<IItemComponentProvider>();
+		}
+
+		this.componentProviders.add(provider);
 	}
 	
 	@Override
@@ -79,6 +97,23 @@ public class ItemArgument extends TagArgument
 		if(this.item == null)
 		{
 			return null;
+		}
+
+		DataComponentPatch.Builder components = DataComponentPatch.builder();
+
+		if(this.componentProviders != null)
+		{
+			for(IItemComponentProvider provider : this.componentProviders)
+			{
+				provider.addItemComponents(components);
+			}
+		}
+
+		DataComponentPatch componentPatch = components.build();
+
+		if(!componentPatch.isEmpty())
+		{
+			return new ItemInput(BuiltInRegistries.ITEM.wrapAsHolder(this.item), componentPatch).serialize(RegistryHelper.registryAccess());
 		}
 		
 		String tag = super.serialize();

--- a/src/main/java/exopandora/worldhandler/builder/argument/ItemPredicateArgument.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/ItemPredicateArgument.java
@@ -7,7 +7,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import exopandora.worldhandler.util.ItemPredicateParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ItemPredicateArgument extends TagArgument
 {
@@ -28,7 +28,7 @@ public class ItemPredicateArgument extends TagArgument
 	{
 		if(item != null)
 		{
-			this.resource = ForgeRegistries.ITEMS.getKey(item);
+			this.resource = BuiltInRegistries.ITEM.getKey(item);
 		}
 		else
 		{

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractAttributeTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractAttributeTag.java
@@ -8,11 +8,11 @@ import java.util.stream.Collectors;
 
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public abstract class AbstractAttributeTag implements ITagProvider
 {	
-	public static final List<Attribute> ATTRIBUTES = ForgeRegistries.ATTRIBUTES.getValues().stream()
+	public static final List<Attribute> ATTRIBUTES = BuiltInRegistries.ATTRIBUTE.stream().toList().stream()
 			.filter(attribute -> !attribute.getDescriptionId().equals(I18n.get(attribute.getDescriptionId())))
 			.collect(Collectors.toList());
 	

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractAttributeTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractAttributeTag.java
@@ -12,7 +12,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 
 public abstract class AbstractAttributeTag implements ITagProvider
 {	
-	public static final List<Attribute> ATTRIBUTES = BuiltInRegistries.ATTRIBUTE.stream().toList().stream()
+	public static final List<Attribute> ATTRIBUTES = BuiltInRegistries.ATTRIBUTE.stream()
 			.filter(attribute -> !attribute.getDescriptionId().equals(I18n.get(attribute.getDescriptionId())))
 			.collect(Collectors.toList());
 	

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractEffectTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AbstractEffectTag.java
@@ -12,7 +12,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.effect.MobEffect;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public abstract class AbstractEffectTag implements ITagProvider 
 {
@@ -33,7 +33,7 @@ public abstract class AbstractEffectTag implements ITagProvider
 				CompoundTag compound = new CompoundTag();
 				int ticks = instance.toTicks();
 				
-				compound.putString("id", ForgeRegistries.MOB_EFFECTS.getKey(entry.getKey()).toString());
+				compound.putString("id", BuiltInRegistries.MOB_EFFECT.getKey(entry.getKey()).toString());
 				compound.putByte("amplifier", (byte) (instance.getAmplifier() - 1));
 				compound.putInt("duration", ticks > 0 ? ticks : 1000000);
 				compound.putBoolean("ambient", instance.isAmbient());

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributeModifiersTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributeModifiersTag.java
@@ -5,13 +5,19 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 
-public class AttributeModifiersTag extends AbstractAttributeTag
+public class AttributeModifiersTag extends AbstractAttributeTag implements IItemComponentProvider
 {
 	@Override
 	@Nullable
@@ -47,5 +53,28 @@ public class AttributeModifiersTag extends AbstractAttributeTag
 	public String key()
 	{
 		return "AttributeModifiers";
+	}
+
+	@Override
+	public void addItemComponents(DataComponentPatch.Builder components)
+	{
+		ItemAttributeModifiers.Builder modifiers = ItemAttributeModifiers.builder();
+		boolean hasModifiers = false;
+
+		for(Entry<Attribute, Double> entry : this.attributes.entrySet())
+		{
+			if(entry.getValue() != 0)
+			{
+				ResourceLocation id = BuiltInRegistries.ATTRIBUTE.getKey(entry.getKey());
+
+				modifiers.add(BuiltInRegistries.ATTRIBUTE.wrapAsHolder(entry.getKey()), new AttributeModifier(id, entry.getValue() / 100, AttributeModifier.Operation.ADD_MULTIPLIED_BASE), EquipmentSlotGroup.ANY);
+				hasModifiers = true;
+			}
+		}
+
+		if(hasModifiers)
+		{
+			components.set(DataComponents.ATTRIBUTE_MODIFIERS, modifiers.build());
+		}
 	}
 }

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributeModifiersTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributeModifiersTag.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class AttributeModifiersTag extends AbstractAttributeTag
 {
@@ -24,7 +24,7 @@ public class AttributeModifiersTag extends AbstractAttributeTag
 			if(entry.getValue() != 0)
 			{
 				CompoundTag attribute = new CompoundTag();
-				String id = ForgeRegistries.ATTRIBUTES.getKey(entry.getKey()).toString();
+				String id = BuiltInRegistries.ATTRIBUTE.getKey(entry.getKey()).toString();
 				
 				attribute.putString("AttributeName", id);
 				attribute.putDouble("Amount", entry.getValue() / 100);

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributesTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/AttributesTag.java
@@ -8,7 +8,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class AttributesTag extends AbstractAttributeTag
 {
@@ -23,7 +23,7 @@ public class AttributesTag extends AbstractAttributeTag
 			if(entry.getValue() != 0)
 			{
 				CompoundTag attribute = new CompoundTag();
-				String id = ForgeRegistries.ATTRIBUTES.getKey(entry.getKey()).toString();
+				String id = BuiltInRegistries.ATTRIBUTE.getKey(entry.getKey()).toString();
 				
 				attribute.putString("Name", id);
 				attribute.putDouble("Base", entry.getValue() / 100);

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/DisplayTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/DisplayTag.java
@@ -1,14 +1,20 @@
 package exopandora.worldhandler.builder.argument.tag;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import exopandora.worldhandler.util.TextUtils;
 import exopandora.worldhandler.util.UserStylableComponent;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.component.ItemLore;
 
-public class DisplayTag implements ITagProvider 
+public class DisplayTag implements ITagProvider, IItemComponentProvider
 {
 	private UserStylableComponent name = new UserStylableComponent();
 	private Component[] lore = new Component[2];
@@ -90,5 +96,29 @@ public class DisplayTag implements ITagProvider
 	public String key()
 	{
 		return "display";
+	}
+
+	@Override
+	public void addItemComponents(DataComponentPatch.Builder components)
+	{
+		if(this.name.getText() != null && !this.name.getText().isEmpty())
+		{
+			components.set(DataComponents.CUSTOM_NAME, this.name);
+		}
+
+		List<Component> lore = new ArrayList<Component>();
+
+		for(int x = 0; x < this.lore.length; x++)
+		{
+			if(this.lore[x] != null && !this.lore[x].getString().isEmpty())
+			{
+				lore.add(this.lore[x]);
+			}
+		}
+
+		if(!lore.isEmpty())
+		{
+			components.set(DataComponents.LORE, new ItemLore(lore));
+		}
 	}
 }

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/DisplayTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/DisplayTag.java
@@ -1,5 +1,6 @@
 package exopandora.worldhandler.builder.argument.tag;
 
+import exopandora.worldhandler.util.TextUtils;
 import exopandora.worldhandler.util.UserStylableComponent;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -19,7 +20,7 @@ public class DisplayTag implements ITagProvider
 		
 		if(this.name.getText() != null && !this.name.getText().isEmpty())
 		{
-			display.putString("Name", Component.Serializer.toJson(this.name));
+			display.putString("Name", TextUtils.toJson(this.name));
 		}
 		
 		ListTag lore = new ListTag();
@@ -28,7 +29,7 @@ public class DisplayTag implements ITagProvider
 		{
 			if(this.lore[x] != null && !this.lore[x].getString().isEmpty())
 			{
-				lore.add(StringTag.valueOf(Component.Serializer.toJson(this.lore[x])));
+				lore.add(StringTag.valueOf(TextUtils.toJson(this.lore[x])));
 			}
 		}
 		

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/EnchantmentsTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/EnchantmentsTag.java
@@ -7,11 +7,11 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import exopandora.worldhandler.util.RegistryHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class EnchantmentsTag implements ITagProvider
 {
@@ -29,7 +29,7 @@ public class EnchantmentsTag implements ITagProvider
 			{
 				CompoundTag enchantment = new CompoundTag();
 				
-				enchantment.putString("id", ForgeRegistries.ENCHANTMENTS.getKey(entry.getKey()).toString());
+				enchantment.putString("id", RegistryHelper.getEnchantmentKey(entry.getKey()).toString());
 				enchantment.putShort("lvl", entry.getValue());
 				
 				enchantments.add(enchantment);

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/EnchantmentsTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/EnchantmentsTag.java
@@ -1,6 +1,7 @@
 package exopandora.worldhandler.builder.argument.tag;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -8,12 +9,16 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import exopandora.worldhandler.util.RegistryHelper;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 
-public class EnchantmentsTag implements ITagProvider
+public class EnchantmentsTag implements ITagProvider, IItemComponentProvider
 {
 	private final Map<Enchantment, Short> enchantments = new HashMap<Enchantment, Short>();
 	
@@ -70,5 +75,27 @@ public class EnchantmentsTag implements ITagProvider
 	public String key()
 	{
 		return "Enchantments";
+	}
+
+	@Override
+	public void addItemComponents(DataComponentPatch.Builder components)
+	{
+		ItemEnchantments.Mutable enchantments = new ItemEnchantments.Mutable(ItemEnchantments.EMPTY);
+
+		for(Entry<Enchantment, Short> entry : this.enchantments.entrySet())
+		{
+			if(entry.getValue() > 0)
+			{
+				Holder<Enchantment> holder = RegistryHelper.enchantments().wrapAsHolder(entry.getKey());
+				enchantments.set(holder, entry.getValue());
+			}
+		}
+
+		ItemEnchantments itemEnchantments = enchantments.toImmutable();
+
+		if(!itemEnchantments.isEmpty())
+		{
+			components.set(DataComponents.ENCHANTMENTS, itemEnchantments);
+		}
 	}
 }

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/EntityTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/EntityTag.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import exopandora.worldhandler.util.NBTHelper;
+import exopandora.worldhandler.util.TextUtils;
 import exopandora.worldhandler.util.UserStylableComponent;
 import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
@@ -405,7 +406,7 @@ public class EntityTag implements ITagProvider
 		
 		if(this.customName.getText() != null && !this.customName.getText().isEmpty())
 		{
-			NBTHelper.append(nbt, "CustomName", StringTag.valueOf(Component.Serializer.toJson(this.customName)));
+			NBTHelper.append(nbt, "CustomName", StringTag.valueOf(TextUtils.toJson(this.customName)));
 		}
 		
 		NBTHelper.append(nbt, this.potion);

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/IItemComponentProvider.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/IItemComponentProvider.java
@@ -1,0 +1,8 @@
+package exopandora.worldhandler.builder.argument.tag;
+
+import net.minecraft.core.component.DataComponentPatch;
+
+public interface IItemComponentProvider
+{
+	void addItemComponents(DataComponentPatch.Builder components);
+}

--- a/src/main/java/exopandora/worldhandler/builder/argument/tag/SidedSignTextTag.java
+++ b/src/main/java/exopandora/worldhandler/builder/argument/tag/SidedSignTextTag.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import javax.annotation.Nonnull;
 
+import exopandora.worldhandler.util.TextUtils;
 import exopandora.worldhandler.util.UserStylableComponent;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -36,7 +37,7 @@ public class SidedSignTextTag implements ITagProvider
 		
 		for(UserStylableComponent text : this.lines)
 		{
-			messages.add(StringTag.valueOf(Component.Serializer.toJson(text)));
+			messages.add(StringTag.valueOf(TextUtils.toJson(text)));
 		}
 		
 		CompoundTag tag = new CompoundTag();

--- a/src/main/java/exopandora/worldhandler/command/CommandWH.java
+++ b/src/main/java/exopandora/worldhandler/command/CommandWH.java
@@ -22,7 +22,7 @@ import net.minecraft.commands.arguments.blocks.BlockPredicateArgument;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class CommandWH
 {
@@ -58,7 +58,7 @@ public class CommandWH
 	{
 		BlockHelper.pos1().set(BlockHelper.getFocusedBlockPos());
 		BlockPos pos = BlockHelper.pos1();
-		ResourceLocation block = ForgeRegistries.BLOCKS.getKey(BlockHelper.getBlock(pos));
+		ResourceLocation block = BuiltInRegistries.BLOCK.getKey(BlockHelper.getBlock(pos));
 		CommandHelper.sendFeedback(source, "Set first position to " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ() + " (" + block + ")");
 		return 1;
 	}
@@ -67,7 +67,7 @@ public class CommandWH
 	{
 		BlockHelper.pos2().set(BlockHelper.getFocusedBlockPos());
 		BlockPos pos = BlockHelper.pos2();
-		ResourceLocation block = ForgeRegistries.BLOCKS.getKey(BlockHelper.getBlock(pos));
+		ResourceLocation block = BuiltInRegistries.BLOCK.getKey(BlockHelper.getBlock(pos));
 		CommandHelper.sendFeedback(source, "Set second position to " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ() + " (" + block + ")");
 		return 1;
 	}

--- a/src/main/java/exopandora/worldhandler/command/CommandWorldHandler.java
+++ b/src/main/java/exopandora/worldhandler/command/CommandWorldHandler.java
@@ -17,8 +17,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.LevelSettings;
 import net.minecraft.world.level.storage.PrimaryLevelData;
-import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.VersionChecker;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.VersionChecker;
 
 public class CommandWorldHandler
 {

--- a/src/main/java/exopandora/worldhandler/config/Config.java
+++ b/src/main/java/exopandora/worldhandler/config/Config.java
@@ -7,16 +7,16 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import net.minecraftforge.common.ForgeConfigSpec;
+import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class Config
 {
-	public static final ForgeConfigSpec CLIENT_SPEC;
+	public static final ModConfigSpec CLIENT_SPEC;
 	public static final ClientConfig CLIENT;
 	
 	static
 	{
-		Pair<ClientConfig, ForgeConfigSpec> pair = new ForgeConfigSpec.Builder().configure(ClientConfig::new);
+		Pair<ClientConfig, ModConfigSpec> pair = new ModConfigSpec.Builder().configure(ClientConfig::new);
 		CLIENT_SPEC = pair.getRight();
 		CLIENT = pair.getLeft();
 	}
@@ -28,7 +28,7 @@ public class Config
 		private final ConfigCategorySkin skin;
 		private final ConfigCategorySliders sliders;
 		
-		public ClientConfig(ForgeConfigSpec.Builder builder)
+		public ClientConfig(ModConfigSpec.Builder builder)
 		{
 			this.settings = new ConfigCategorySettings(builder);
 			this.butcher = new ConfigCategoryButcher(builder);
@@ -77,7 +77,7 @@ public class Config
 		return Config.CLIENT.getSliders();
 	}
 	
-	protected static <T> void set(ForgeConfigSpec.ConfigValue<T> configValue, T value)
+	protected static <T> void set(ModConfigSpec.ConfigValue<T> configValue, T value)
 	{
 		if(configValue != null && value != null && (!value.equals(configValue.get()) || configValue.get() instanceof List<?>))
 		{

--- a/src/main/java/exopandora/worldhandler/config/ConfigCategoryButcher.java
+++ b/src/main/java/exopandora/worldhandler/config/ConfigCategoryButcher.java
@@ -7,15 +7,15 @@ import java.util.stream.Collectors;
 import com.google.common.base.Predicates;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.common.ModConfigSpec.ConfigValue;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ConfigCategoryButcher
 {
 	private final ConfigValue<List<? extends String>> entities;
 	
-	public ConfigCategoryButcher(ForgeConfigSpec.Builder builder)
+	public ConfigCategoryButcher(ModConfigSpec.Builder builder)
 	{
 		builder.push("butcher");
 		
@@ -63,7 +63,7 @@ public class ConfigCategoryButcher
 	{
 		if(string != null)
 		{
-			return ForgeRegistries.ENTITY_TYPES.containsKey(ResourceLocation.tryParse(string.toString()));
+			return BuiltInRegistries.ENTITY_TYPE.containsKey(ResourceLocation.tryParse(string.toString()));
 		}
 		
 		return false;

--- a/src/main/java/exopandora/worldhandler/config/ConfigCategorySettings.java
+++ b/src/main/java/exopandora/worldhandler/config/ConfigCategorySettings.java
@@ -1,10 +1,10 @@
 package exopandora.worldhandler.config;
 
 import exopandora.worldhandler.util.BlockPlacingMode;
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
-import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
-import net.minecraftforge.common.ForgeConfigSpec.IntValue;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.common.ModConfigSpec.BooleanValue;
+import net.neoforged.neoforge.common.ModConfigSpec.ConfigValue;
+import net.neoforged.neoforge.common.ModConfigSpec.IntValue;
 
 public class ConfigCategorySettings
 {
@@ -23,7 +23,7 @@ public class ConfigCategorySettings
 	private final IntValue midnight;
 	private final ConfigValue<BlockPlacingMode> blockPlacingMode;
 	
-	public ConfigCategorySettings(ForgeConfigSpec.Builder builder)
+	public ConfigCategorySettings(ModConfigSpec.Builder builder)
 	{
 		builder.push("settings");
 		

--- a/src/main/java/exopandora/worldhandler/config/ConfigCategorySkin.java
+++ b/src/main/java/exopandora/worldhandler/config/ConfigCategorySkin.java
@@ -1,9 +1,9 @@
 package exopandora.worldhandler.config;
 
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
-import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
-import net.minecraftforge.common.ForgeConfigSpec.IntValue;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.common.ModConfigSpec.BooleanValue;
+import net.neoforged.neoforge.common.ModConfigSpec.ConfigValue;
+import net.neoforged.neoforge.common.ModConfigSpec.IntValue;
 
 public class ConfigCategorySkin
 {
@@ -21,7 +21,7 @@ public class ConfigCategorySkin
 	private final BooleanValue sharpEdges;
 	private final BooleanValue drawBackground;
 	
-	public ConfigCategorySkin(ForgeConfigSpec.Builder builder)
+	public ConfigCategorySkin(ModConfigSpec.Builder builder)
 	{
 		builder.push("skin");
 		

--- a/src/main/java/exopandora/worldhandler/config/ConfigCategorySliders.java
+++ b/src/main/java/exopandora/worldhandler/config/ConfigCategorySliders.java
@@ -1,7 +1,7 @@
 package exopandora.worldhandler.config;
 
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.common.ModConfigSpec.DoubleValue;
 
 public class ConfigCategorySliders
 {
@@ -15,7 +15,7 @@ public class ConfigCategorySliders
 	private final DoubleValue maxPlayerPoints;
 	private final DoubleValue maxTriggerValue;
 	
-	public ConfigCategorySliders(ForgeConfigSpec.Builder builder)
+	public ConfigCategorySliders(ModConfigSpec.Builder builder)
 	{
 		builder.push("sliders");
 		

--- a/src/main/java/exopandora/worldhandler/event/ClientEventHandler.java
+++ b/src/main/java/exopandora/worldhandler/event/ClientEventHandler.java
@@ -13,10 +13,9 @@ import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.client.event.RenderLevelStageEvent;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.TickEvent.ClientTickEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.bus.api.SubscribeEvent;
 
 public class ClientEventHandler
 {
@@ -59,9 +58,9 @@ public class ClientEventHandler
 	}
 	
 	@SubscribeEvent
-	public static void clientTickEvent(ClientTickEvent event)
+	public static void clientTickEvent(ClientTickEvent.Pre event)
 	{
-		if(TickEvent.Phase.START.equals(event.phase) && ClientEventHandler.openGui)
+		if(ClientEventHandler.openGui)
 		{
 			ClientEventHandler.openGui = false;
 			ActionHelper.displayGui();

--- a/src/main/java/exopandora/worldhandler/event/KeyHandler.java
+++ b/src/main/java/exopandora/worldhandler/event/KeyHandler.java
@@ -6,8 +6,8 @@ import exopandora.worldhandler.util.ActionHelper;
 import exopandora.worldhandler.util.BlockHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import net.minecraftforge.client.event.InputEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.event.InputEvent;
+import net.neoforged.bus.api.SubscribeEvent;
 
 public class KeyHandler
 {

--- a/src/main/java/exopandora/worldhandler/gui/category/Categories.java
+++ b/src/main/java/exopandora/worldhandler/gui/category/Categories.java
@@ -15,7 +15,7 @@ public class Categories
 	
 	public static Category getRegisteredCategory(String name)
 	{
-		Category category = Category.REGISTRY.getValue(new ResourceLocation(Main.MODID, name));
+		Category category = Category.REGISTRY.get(ResourceLocation.fromNamespaceAndPath(Main.MODID, name));
 		
 		if(category == null)
 		{
@@ -27,6 +27,6 @@ public class Categories
 	
 	public static boolean isRegistered(String name)
 	{
-		return Category.REGISTRY.containsKey(new ResourceLocation(Main.MODID, name));
+		return Category.REGISTRY.containsKey(ResourceLocation.fromNamespaceAndPath(Main.MODID, name));
 	}
 }

--- a/src/main/java/exopandora/worldhandler/gui/category/Category.java
+++ b/src/main/java/exopandora/worldhandler/gui/category/Category.java
@@ -20,16 +20,15 @@ import exopandora.worldhandler.util.RegistryHelper;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.registries.IForgeRegistry;
-import net.minecraftforge.registries.NewRegistryEvent;
-import net.minecraftforge.registries.RegisterEvent;
-import net.minecraftforge.registries.RegistryBuilder;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.registries.NewRegistryEvent;
+import net.neoforged.neoforge.registries.RegisterEvent;
+import net.neoforged.neoforge.registries.RegistryBuilder;
 
 public class Category
 {
-	public static IForgeRegistry<Category> REGISTRY;
-	public static final ResourceKey<Registry<Category>> REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation(Main.MODID, "category"));
+	public static Registry<Category> REGISTRY;
+	public static final ResourceKey<Registry<Category>> REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(Main.MODID, "category"));
 	public static final Map<String, List<String>> DEFAULT_CATEGORIES = new CategoriesBuilder()
 		.add("main", "main", "containers", "multiplayer")
 		.add("entities", "summon", "butcher")
@@ -65,7 +64,7 @@ public class Category
 	
 	public Category add(int index, String key)
 	{
-		return this.add(index, new ResourceLocation(Main.MODID, key));
+		return this.add(index, ResourceLocation.fromNamespaceAndPath(Main.MODID, key));
 	}
 	
 	public List<ResourceLocation> getContents()
@@ -81,16 +80,13 @@ public class Category
 	@Nullable
 	public Content getContent(int index)
 	{
-		return Content.REGISTRY.getValue(this.contents.get(index));
+		return Content.REGISTRY.get(this.contents.get(index));
 	}
 	
 	@SubscribeEvent
 	public static void createRegistry(NewRegistryEvent event)
 	{
-		event.create(new RegistryBuilder<Category>()
-			.setName(REGISTRY_KEY.location())
-			.disableSaving()
-			.disableSync(), registry -> REGISTRY = registry);
+		REGISTRY = event.create(new RegistryBuilder<Category>(REGISTRY_KEY).sync(false));
 	}
 	
 	@SubscribeEvent
@@ -103,7 +99,7 @@ public class Category
 				RegistryHelper.register(event, REGISTRY_KEY, entry.getKey(), () ->
 				{
 					var keys = entry.getValue().stream()
-						.map(key -> new ResourceLocation(Main.MODID, key))
+						.map(key -> ResourceLocation.fromNamespaceAndPath(Main.MODID, key))
 						.collect(Collectors.toList());
 					return new Category(keys);
 				});
@@ -125,7 +121,7 @@ public class Category
 		{
 			if(!Categories.isRegistered(tab.getCategory()))
 			{
-				RegistryHelper.register(event, REGISTRY_KEY, tab.getCategory(), () -> new Category(new ResourceLocation(Main.MODID, id)));
+				RegistryHelper.register(event, REGISTRY_KEY, tab.getCategory(), () -> new Category(ResourceLocation.fromNamespaceAndPath(Main.MODID, id)));
 			}
 			else
 			{

--- a/src/main/java/exopandora/worldhandler/gui/container/impl/GuiWorldHandler.java
+++ b/src/main/java/exopandora/worldhandler/gui/container/impl/GuiWorldHandler.java
@@ -42,7 +42,7 @@ public class GuiWorldHandler extends Container
 		widgets.add(new WidgetCommandSyntax());
 		widgets.add(new WidgetShortcuts());
 	});
-	private static final ResourceLocation BACKGROUND_TEXTURE = new ResourceLocation("textures/gui/demo_background.png");
+	private static final ResourceLocation BACKGROUND_TEXTURE = ResourceLocation.parse("textures/gui/demo_background.png");
 	
 	private final Content content;
 	

--- a/src/main/java/exopandora/worldhandler/gui/content/Content.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/Content.java
@@ -38,24 +38,20 @@ import exopandora.worldhandler.util.RegistryHelper;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.registries.IForgeRegistry;
-import net.minecraftforge.registries.NewRegistryEvent;
-import net.minecraftforge.registries.RegisterEvent;
-import net.minecraftforge.registries.RegistryBuilder;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.registries.NewRegistryEvent;
+import net.neoforged.neoforge.registries.RegisterEvent;
+import net.neoforged.neoforge.registries.RegistryBuilder;
 
 public abstract class Content implements IContent
 {
-	public static IForgeRegistry<Content> REGISTRY;
-	public static final ResourceKey<Registry<Content>> REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation(Main.MODID, "content"));
+	public static Registry<Content> REGISTRY;
+	public static final ResourceKey<Registry<Content>> REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(Main.MODID, "content"));
 	
 	@SubscribeEvent
 	public static void createRegistry(NewRegistryEvent event)
 	{
-		event.create(new RegistryBuilder<Content>()
-			.setName(REGISTRY_KEY.location())
-			.disableSaving()
-			.disableSync(), registry -> REGISTRY = registry);
+		REGISTRY = event.create(new RegistryBuilder<Content>(REGISTRY_KEY).sync(false));
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/exopandora/worldhandler/gui/content/Contents.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/Contents.java
@@ -46,7 +46,7 @@ public class Contents
 	
 	public static Content getRegisteredContent(String name)
 	{
-		Content content = Content.REGISTRY.getValue(new ResourceLocation(Main.MODID, name));
+		Content content = Content.REGISTRY.get(ResourceLocation.fromNamespaceAndPath(Main.MODID, name));
 		
 		if(content == null)
 		{
@@ -58,6 +58,6 @@ public class Contents
 	
 	public static boolean isRegistered(String name)
 	{
-		return Content.REGISTRY.containsKey(new ResourceLocation(Main.MODID, name));
+		return Content.REGISTRY.containsKey(ResourceLocation.fromNamespaceAndPath(Main.MODID, name));
 	}
 }

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcher.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcher.java
@@ -26,7 +26,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentButcher extends Content
 {
@@ -102,7 +102,7 @@ public class ContentButcher extends Content
 		
 		container.addRenderableWidget(slaughter = new GuiButtonBase(x + 58, y + 48, 114, 20, Component.translatable("gui.worldhandler.butcher.slaughter"), () ->
 		{
-			Collection<EntityType<?>> entities = Config.getButcher().getEntities().stream().map(ForgeRegistries.ENTITY_TYPES::getValue).filter(Predicates.notNull()).collect(Collectors.toList());
+			Collection<EntityType<?>> entities = Config.getButcher().getEntities().stream().map(BuiltInRegistries.ENTITY_TYPE::get).filter(Predicates.notNull()).collect(Collectors.toList());
 			ContentButcher.slaughter(container.getPlayer(), entities, Integer.parseInt(this.radius));
 		}));
 		slaughter.active = enabled && !Config.getButcher().getEntities().isEmpty();
@@ -132,7 +132,7 @@ public class ContentButcher extends Content
 				{
 					KillCommandBuilder kill = new KillCommandBuilder();
 					kill.targets().setSelectorType(SelectorTypes.ALL_ENTITIES);
-					kill.targets().setType(ForgeRegistries.ENTITY_TYPES.getKey(entity));
+					kill.targets().setType(BuiltInRegistries.ENTITY_TYPE.getKey(entity));
 					kill.targets().setDistanceMax(radius);
 					CommandHelper.sendCommand(username, kill, KillCommandBuilder.Label.KILL_TARGETS);
 				}

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherPresets.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherPresets.java
@@ -9,7 +9,7 @@ import exopandora.worldhandler.util.ActionHelper;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentButcherPresets extends ContentChild
 {
@@ -42,22 +42,22 @@ public class ContentButcherPresets extends ContentChild
 		
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.passive_mobs"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), ForgeRegistries.ENTITY_TYPES.getValues().stream().filter(entity -> !MobCategory.MONSTER.equals(entity.getCategory()) && !MobCategory.MISC.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> !MobCategory.MONSTER.equals(entity.getCategory()) && !MobCategory.MISC.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 24, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.hostile_mobs"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), ForgeRegistries.ENTITY_TYPES.getValues().stream().filter(entity -> MobCategory.MONSTER.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> MobCategory.MONSTER.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 48, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.players"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), ForgeRegistries.ENTITY_TYPES.getValues().stream().filter(entity -> EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 72, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.entities"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), ForgeRegistries.ENTITY_TYPES.getValues().stream().filter(entity -> MobCategory.MISC.equals(entity.getCategory()) && !EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> MobCategory.MISC.equals(entity.getCategory()) && !EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 	}

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherPresets.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherPresets.java
@@ -42,22 +42,22 @@ public class ContentButcherPresets extends ContentChild
 		
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.passive_mobs"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> !MobCategory.MONSTER.equals(entity.getCategory()) && !MobCategory.MISC.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().filter(entity -> !MobCategory.MONSTER.equals(entity.getCategory()) && !MobCategory.MISC.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 24, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.hostile_mobs"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> MobCategory.MONSTER.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().filter(entity -> MobCategory.MONSTER.equals(entity.getCategory())).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 48, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.players"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().filter(entity -> EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 		container.addRenderableWidget(new GuiButtonBase(x + 58, y + 72, 114, 20, Component.translatable("gui.worldhandler.butcher.presets.entities"), () ->
 		{
-			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(entity -> MobCategory.MISC.equals(entity.getCategory()) && !EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
+			ContentButcher.slaughter(container.getPlayer(), BuiltInRegistries.ENTITY_TYPE.stream().filter(entity -> MobCategory.MISC.equals(entity.getCategory()) && !EntityType.PLAYER.equals(entity)).collect(Collectors.toList()), this.radius);
 			ActionHelper.open(this.getParentContent());
 		}));
 	}

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherSettings.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherSettings.java
@@ -24,7 +24,7 @@ public class ContentButcherSettings extends ContentChild
 	@Override
 	public void initGui(Container container, int x, int y)
 	{
-		List<EntityType<?>> list = BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(EntityType::canSummon).collect(Collectors.toList());
+		List<EntityType<?>> list = BuiltInRegistries.ENTITY_TYPE.stream().filter(EntityType::canSummon).collect(Collectors.toList());
 		
 		MenuPageList<EntityType<?>> entities = new MenuPageList<EntityType<?>>(x, y, list, 114, 20, 3, container, new ILogicPageList<EntityType<?>>()
 		{

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherSettings.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentButcherSettings.java
@@ -15,7 +15,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentButcherSettings extends ContentChild
 {
@@ -24,7 +24,7 @@ public class ContentButcherSettings extends ContentChild
 	@Override
 	public void initGui(Container container, int x, int y)
 	{
-		List<EntityType<?>> list = ForgeRegistries.ENTITY_TYPES.getValues().stream().filter(EntityType::canSummon).collect(Collectors.toList());
+		List<EntityType<?>> list = BuiltInRegistries.ENTITY_TYPE.stream().toList().stream().filter(EntityType::canSummon).collect(Collectors.toList());
 		
 		MenuPageList<EntityType<?>> entities = new MenuPageList<EntityType<?>>(x, y, list, 114, 20, 3, container, new ILogicPageList<EntityType<?>>()
 		{
@@ -37,13 +37,13 @@ public class ContentButcherSettings extends ContentChild
 			@Override
 			public MutableComponent toTooltip(EntityType<?> item)
 			{
-				return Component.literal(ForgeRegistries.ENTITY_TYPES.getKey(item).toString());
+				return Component.literal(BuiltInRegistries.ENTITY_TYPE.getKey(item).toString());
 			}
 			
 			@Override
 			public void onClick(EntityType<?> item)
 			{
-				ContentButcherSettings.this.entity = ForgeRegistries.ENTITY_TYPES.getKey(item);
+				ContentButcherSettings.this.entity = BuiltInRegistries.ENTITY_TYPE.getKey(item);
 				container.initButtons();
 			}
 			

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentChangeWorld.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentChangeWorld.java
@@ -11,12 +11,13 @@ import exopandora.worldhandler.util.IConnection.DedicatedConnection;
 import exopandora.worldhandler.util.IConnection.IntegratedConnection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConnectScreen;
-import net.minecraft.client.gui.screens.GenericDirtMessageScreen;
+import net.minecraft.client.gui.screens.GenericMessageScreen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.gui.screens.multiplayer.SafetyScreen;
 import net.minecraft.client.gui.screens.worldselection.SelectWorldScreen;
 import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.TransferState;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -62,7 +63,7 @@ public class ContentChangeWorld extends ContentChild
 		if(isIntegrated)
 		{
 			String folder = minecraft.getSingleplayerServer().storageSource.getLevelId();
-			minecraft.disconnect(new GenericDirtMessageScreen(Component.translatable("menu.savingLevel")));
+			minecraft.disconnect(new GenericMessageScreen(Component.translatable("menu.savingLevel")));
 			return new IntegratedConnection(folder);
 		}
 		else
@@ -86,7 +87,7 @@ public class ContentChangeWorld extends ContentChild
 		}
 		else if(connection instanceof IntegratedConnection integrated)
 		{
-			Minecraft.getInstance().createWorldOpenFlows().checkForBackupAndLoad(integrated.getFolder(), () ->
+			Minecraft.getInstance().createWorldOpenFlows().openWorld(integrated.getFolder(), () ->
 			{
 				Minecraft.getInstance().setScreen(new TitleScreen());
 			});
@@ -95,7 +96,7 @@ public class ContentChangeWorld extends ContentChild
 		else if(connection instanceof DedicatedConnection dedicated)
 		{
 			ServerData data = dedicated.getData();
-			ConnectScreen.startConnecting(new TitleScreen(), Minecraft.getInstance(), ServerAddress.parseString(data.ip), data, false);
+			ConnectScreen.startConnecting(new TitleScreen(), Minecraft.getInstance(), ServerAddress.parseString(data.ip), data, false, (TransferState) null);
 		}
 	}
 	

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCommandStack.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCommandStack.java
@@ -30,7 +30,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentCommandStack extends ContentChild
 {
@@ -59,14 +59,14 @@ public class ContentCommandStack extends ContentChild
 		this.activatorRail.setBlockState(Blocks.ACTIVATOR_RAIL.defaultBlockState());
 		this.builderCommandStack.nbt().addTagProvider(this.activatorRail);
 		
-		EntityTag redstoneBlock = new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.FALLING_BLOCK));
+		EntityTag redstoneBlock = new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.FALLING_BLOCK));
 		redstoneBlock.setTime(1);
 		redstoneBlock.setBlockState(Blocks.REDSTONE_BLOCK.defaultBlockState());
 		this.activatorRail.addPassenger(redstoneBlock);
 		
 		this.addCommand(0);
 		
-		EntityTag blockRemover = new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.COMMAND_BLOCK_MINECART));
+		EntityTag blockRemover = new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COMMAND_BLOCK_MINECART));
 		SetBlockCommandBuilder builder = new SetBlockCommandBuilder();
 		builder.pos().setX(new Coordinate.Ints(Coordinate.Type.RELATIVE));
 		builder.pos().setY(new Coordinate.Ints(-2, Coordinate.Type.RELATIVE));
@@ -87,10 +87,10 @@ public class ContentCommandStack extends ContentChild
 		blockRemover.setCommand(builder.toCommand(SetBlockCommandBuilder.Label.DESTROY, false));
 		this.activatorRail.addPassenger(blockRemover);
 		
-		EntityTag entityRemover = new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.COMMAND_BLOCK_MINECART));
+		EntityTag entityRemover = new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COMMAND_BLOCK_MINECART));
 		KillCommandBuilder kill = new KillCommandBuilder();
 		kill.targets().setSelectorType(SelectorTypes.ALL_ENTITIES);
-		kill.targets().setType(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.COMMAND_BLOCK_MINECART));
+		kill.targets().setType(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COMMAND_BLOCK_MINECART));
 		kill.targets().setDistanceMax(1.0D);
 		entityRemover.setCommand(kill.toCommand(KillCommandBuilder.Label.KILL_TARGETS, false));
 		this.activatorRail.addPassenger(entityRemover);
@@ -246,7 +246,7 @@ public class ContentCommandStack extends ContentChild
 	
 	private void addCommand(int index)
 	{
-		this.activatorRail.addPassenger(index + HEAD_LENGTH, new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.COMMAND_BLOCK_MINECART)));
+		this.activatorRail.addPassenger(index + HEAD_LENGTH, new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COMMAND_BLOCK_MINECART)));
 	}
 	
 	private void removeCommand(int index)

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCustomItem.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCustomItem.java
@@ -52,9 +52,9 @@ public class ContentCustomItem extends Content
 	
 	public ContentCustomItem()
 	{
-		this.builderCutomItem.item().addTagProvider(this.attributes);
-		this.builderCutomItem.item().addTagProvider(this.display);
-		this.builderCutomItem.item().addTagProvider(this.enchantments);
+		this.builderCutomItem.item().addComponentProvider(this.attributes);
+		this.builderCutomItem.item().addComponentProvider(this.display);
+		this.builderCutomItem.item().addComponentProvider(this.enchantments);
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCustomItem.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentCustomItem.java
@@ -26,12 +26,13 @@ import exopandora.worldhandler.gui.widget.menu.impl.MenuPageList;
 import exopandora.worldhandler.util.ActionHandler;
 import exopandora.worldhandler.util.ActionHelper;
 import exopandora.worldhandler.util.CommandHelper;
+import exopandora.worldhandler.util.RegistryHelper;
 import exopandora.worldhandler.util.TextUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentCustomItem extends Content
 {
@@ -131,18 +132,18 @@ public class ContentCustomItem extends Content
 		}
 		else if(Page.ENCHANT.equals(this.page))
 		{
-			MenuPageList<Enchantment> enchantments = new MenuPageList<Enchantment>(x + 118, y, new ArrayList<Enchantment>(ForgeRegistries.ENCHANTMENTS.getValues()), 114, 20, 3, container, new ILogicPageList<Enchantment>()
+			MenuPageList<Enchantment> enchantments = new MenuPageList<Enchantment>(x + 118, y, new ArrayList<Enchantment>(RegistryHelper.enchantmentValues()), 114, 20, 3, container, new ILogicPageList<Enchantment>()
 			{
 				@Override
 				public MutableComponent translate(Enchantment item)
 				{
-					return Component.translatable(item.getDescriptionId());
+					return RegistryHelper.getEnchantmentDescription(item).copy();
 				}
 				
 				@Override
 				public MutableComponent toTooltip(Enchantment item)
 				{
-					return Component.literal(ForgeRegistries.ENCHANTMENTS.getKey(item).toString());
+					return Component.literal(RegistryHelper.getEnchantmentKey(item).toString());
 				}
 				
 				@Override
@@ -154,7 +155,7 @@ public class ContentCustomItem extends Content
 				@Override
 				public GuiButtonBase onRegister(int x, int y, int width, int height, MutableComponent text, Enchantment item, ActionHandler actionHandler)
 				{
-					return new GuiSlider(x, y, width, height, 0, Config.getSliders().getMaxItemEnchantment(), 0, container, new LogicSliderSimple(ForgeRegistries.ENCHANTMENTS.getKey(item).toString(), text, value ->
+					return new GuiSlider(x, y, width, height, 0, Config.getSliders().getMaxItemEnchantment(), 0, container, new LogicSliderSimple(RegistryHelper.getEnchantmentKey(item).toString(), text, value ->
 					{
 						ContentCustomItem.this.enchantments.set(item, value.shortValue());
 					}));
@@ -187,7 +188,7 @@ public class ContentCustomItem extends Content
 				@Override
 				public MutableComponent toTooltip(Attribute attribute)
 				{
-					return Component.literal(ForgeRegistries.ATTRIBUTES.getKey(attribute).toString());
+					return Component.literal(BuiltInRegistries.ATTRIBUTE.getKey(attribute).toString());
 				}
 				
 				@Override

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentEnchantment.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentEnchantment.java
@@ -17,10 +17,10 @@ import exopandora.worldhandler.gui.widget.menu.impl.MenuPageList;
 import exopandora.worldhandler.util.ActionHandler;
 import exopandora.worldhandler.util.ActionHelper;
 import exopandora.worldhandler.util.CommandHelper;
+import exopandora.worldhandler.util.RegistryHelper;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class ContentEnchantment extends Content
 {
@@ -36,18 +36,18 @@ public class ContentEnchantment extends Content
 	@Override
 	public void initGui(Container container, int x, int y)
 	{
-		MenuPageList<Enchantment> enchantments = new MenuPageList<Enchantment>(x, y, new ArrayList<Enchantment>(ForgeRegistries.ENCHANTMENTS.getValues()), 114, 20, 3, container, new ILogicPageList<Enchantment>()
+		MenuPageList<Enchantment> enchantments = new MenuPageList<Enchantment>(x, y, new ArrayList<Enchantment>(RegistryHelper.enchantmentValues()), 114, 20, 3, container, new ILogicPageList<Enchantment>()
 		{
 			@Override
 			public MutableComponent translate(Enchantment enchantment)
 			{
-				return Component.translatable(enchantment.getDescriptionId());
+				return RegistryHelper.getEnchantmentDescription(enchantment).copy();
 			}
 			
 			@Override
 			public MutableComponent toTooltip(Enchantment enchantment)
 			{
-				return Component.literal(ForgeRegistries.ENCHANTMENTS.getKey(enchantment).toString());
+				return Component.literal(RegistryHelper.getEnchantmentKey(enchantment).toString());
 			}
 			
 			@Override

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentLocate.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentLocate.java
@@ -28,7 +28,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentLocate extends Content
 {
@@ -114,7 +114,7 @@ public class ContentLocate extends Content
 					.thenAccept(structures -> this.structures.set(structures.getList().stream()
 						.map(Suggestion::getText)
 						.filter(suggestion -> !suggestion.startsWith("#"))
-						.map(ResourceLocation::new)
+						.map(ResourceLocation::parse)
 						.collect(Collectors.toList())))
 					.thenRun(container::init);
 			}
@@ -158,7 +158,7 @@ public class ContentLocate extends Content
 		}
 		else if(Page.POI.equals(this.page))
 		{
-			List<ResourceLocation> pois = new ArrayList<ResourceLocation>(ForgeRegistries.POI_TYPES.getKeys());
+			List<ResourceLocation> pois = new ArrayList<ResourceLocation>(BuiltInRegistries.POINT_OF_INTEREST_TYPE.keySet());
 			MenuPageList<ResourceLocation> list = new MenuPageList<ResourceLocation>(x + 118, y, pois, 114, 20, 3, container, new ILogicPageList<ResourceLocation>()
 			{
 				@Override

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentNoteEditor.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentNoteEditor.java
@@ -37,7 +37,7 @@ import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 
 public class ContentNoteEditor extends Content
 {
-	private static final ResourceLocation NOTE = new ResourceLocation(Main.MODID, "textures/misc/note.png");
+	private static final ResourceLocation NOTE = ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/misc/note.png");
 	
 	private final SetBlockCommandBuilder builderNoteEditor = new SetBlockCommandBuilder();
 	private final CommandPreview preview = new CommandPreview(this.builderNoteEditor, SetBlockCommandBuilder.Label.REPLACE);
@@ -66,7 +66,7 @@ public class ContentNoteEditor extends Content
 		if(this.isActive)
 		{
 			BlockPos pos = this.builderNoteEditor.pos().getBlockPos();
-			SoundEvent sound = getSoundEvent(pos).getSoundEvent().get();
+			SoundEvent sound = getSoundEvent(pos).getSoundEvent().value();
 			
 			container.addRenderableWidget(new GuiButtonPiano(x - 3 + 15, y, 14, 92, Component.translatable("gui.worldhandler.blocks.note_block_editor.g"), sound, 0.53F, Type.NORMAL, () -> this.setNote(container.getPlayer(), 1)));
 			container.addRenderableWidget(new GuiButtonPiano(x - 3 + 15 * 2, y, 14, 92, Component.translatable("gui.worldhandler.blocks.note_block_editor.a"), sound, 0.6F, Type.NORMAL, () -> this.setNote(container.getPlayer(), 3)));

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentPlayer.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentPlayer.java
@@ -188,7 +188,7 @@ public class ContentPlayer extends Content
 			guiGraphics.drawString(minecraft.font, minecraft.player.getName(), container.width / 2 - playerNameWidth + 59, yPos - 73, 0xE0E0E0);
 			
 			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-			InventoryScreen.renderEntityInInventoryFollowsMouse(guiGraphics, xPos, yPos, 30, xPos - mouseX, yPos - mouseY - 44, 0.0625F, (float) mouseX, (float) mouseY, minecraft.player);
+			InventoryScreen.renderEntityInInventoryFollowsMouse(guiGraphics, xPos - 30, yPos - 70, xPos + 30, yPos, 30, 0.0625F, (float) mouseX, (float) mouseY, minecraft.player);
 			RenderSystem.defaultBlendFunc();
 		}
 	}

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentPotions.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentPotions.java
@@ -24,7 +24,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentPotions extends ContentChild
 {
@@ -72,7 +72,7 @@ public class ContentPotions extends ContentChild
 	@Override
 	public void initGui(Container container, int x, int y)
 	{
-		MenuPageList<MobEffect> potions = new MenuPageList<MobEffect>(x, y, new ArrayList<MobEffect>(ForgeRegistries.MOB_EFFECTS.getValues()), 114, 20, 3, container, new ILogicPageList<MobEffect>()
+		MenuPageList<MobEffect> potions = new MenuPageList<MobEffect>(x, y, new ArrayList<MobEffect>(BuiltInRegistries.MOB_EFFECT.stream().toList()), 114, 20, 3, container, new ILogicPageList<MobEffect>()
 		{
 			@Override
 			public MutableComponent translate(MobEffect effect)
@@ -83,7 +83,7 @@ public class ContentPotions extends ContentChild
 			@Override
 			public MutableComponent toTooltip(MobEffect effect)
 			{
-				return Component.literal(ForgeRegistries.MOB_EFFECTS.getKey(effect).toString());
+				return Component.literal(BuiltInRegistries.MOB_EFFECT.getKey(effect).toString());
 			}
 			
 			@Override
@@ -163,7 +163,7 @@ public class ContentPotions extends ContentChild
 				tag.setShowParticles(!tag.doShowParticles());
 				container.init();
 			}));
-			container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 1, Config.getSliders().getMaxPotionAmplifier(), 1, container, new LogicSliderSimple("amplifier" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable("gui.worldhandler.potions.effect.amplifier"), value ->
+			container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 1, Config.getSliders().getMaxPotionAmplifier(), 1, container, new LogicSliderSimple("amplifier" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable("gui.worldhandler.potions.effect.amplifier"), value ->
 			{
 				this.builderPotion.amplifier().set((byte) (value.byteValue() - 1));
 				tag.setAmplifier(value.byteValue());
@@ -174,17 +174,17 @@ public class ContentPotions extends ContentChild
 			MobEffect effect = this.builderPotion.effect().getEffect();
 			EffectInstance tag = this.effects.getOrCreate(effect);
 			
-			container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 0, 59, 0, container, new LogicSliderSimple("s" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable("gui.worldhandler.potion.time.seconds"), value ->
+			container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 0, 59, 0, container, new LogicSliderSimple("s" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable("gui.worldhandler.potion.time.seconds"), value ->
 			{
 				tag.setSeconds(value.intValue());
 				this.builderPotion.seconds().set(tag.toSeconds());
 			})));
-			container.addRenderableWidget(new GuiSlider(x + 118, y + 24, 114, 20, 0, 59, 0, container, new LogicSliderSimple("m" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable("gui.worldhandler.potion.time.minutes"), value ->
+			container.addRenderableWidget(new GuiSlider(x + 118, y + 24, 114, 20, 0, 59, 0, container, new LogicSliderSimple("m" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable("gui.worldhandler.potion.time.minutes"), value ->
 			{
 				tag.setMinutes(value.intValue());
 				this.builderPotion.seconds().set(tag.toSeconds());
 			})));
-			container.addRenderableWidget(new GuiSlider(x + 118, y + 48, 114, 20, 0, 99, 0, container, new LogicSliderSimple("h" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable("gui.worldhandler.potion.time.hours"), value ->
+			container.addRenderableWidget(new GuiSlider(x + 118, y + 48, 114, 20, 0, 99, 0, container, new LogicSliderSimple("h" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable("gui.worldhandler.potion.time.hours"), value ->
 			{
 				tag.setHours(value.intValue());
 				this.builderPotion.seconds().set(tag.toSeconds());

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentScoreboardObjectives.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentScoreboardObjectives.java
@@ -25,8 +25,8 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.stats.StatType;
 import net.minecraft.stats.Stats;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 
 public class ContentScoreboardObjectives extends ContentScoreboard
 {
@@ -63,7 +63,7 @@ public class ContentScoreboardObjectives extends ContentScoreboard
 					
 					if(resource != null)
 					{
-						StatType<?> type = ForgeRegistries.STAT_TYPES.getValue(resource);
+						StatType<?> type = BuiltInRegistries.STAT_TYPE.get(resource);
 						
 						if(type != null)
 						{
@@ -144,9 +144,9 @@ public class ContentScoreboardObjectives extends ContentScoreboard
 				@Nullable
 				private boolean isRegistryItem(ResourceLocation resource)
 				{
-					IForgeRegistry<?>[] registries = new IForgeRegistry<?>[] {ForgeRegistries.BLOCKS, ForgeRegistries.ITEMS, ForgeRegistries.ENTITY_TYPES};
+					Registry<?>[] registries = new Registry<?>[] {BuiltInRegistries.BLOCK, BuiltInRegistries.ITEM, BuiltInRegistries.ENTITY_TYPE};
 					
-					for(IForgeRegistry<?> registry : registries)
+					for(Registry<?> registry : registries)
 					{
 						if(registry.containsKey(resource))
 						{
@@ -154,7 +154,7 @@ public class ContentScoreboardObjectives extends ContentScoreboard
 						}
 					}
 					
-					return ForgeRegistries.STAT_TYPES.containsKey(resource);
+					return BuiltInRegistries.STAT_TYPE.containsKey(resource);
 				}
 			});
 			

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentSummon.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentSummon.java
@@ -57,11 +57,11 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ContentSummon extends Content
 {
-	private static final ResourceLocation BEACON_LOCATION = new ResourceLocation("textures/gui/container/beacon.png");
+	private static final ResourceLocation BEACON_LOCATION = ResourceLocation.parse("textures/gui/container/beacon.png");
 	private static final Item[] HELMETS =
 	{
 		Items.AIR,
@@ -246,7 +246,7 @@ public class ContentSummon extends Content
 				@Override
 				public MutableComponent toTooltip(Attribute attribute)
 				{
-					return Component.literal(ForgeRegistries.ATTRIBUTES.getKey(attribute).toString());
+					return Component.literal(BuiltInRegistries.ATTRIBUTE.getKey(attribute).toString());
 				}
 				
 				@Override
@@ -345,7 +345,7 @@ public class ContentSummon extends Content
 			
 			for(ResourceLocation location : this.sortedEffects())
 			{
-				MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(location);
+				MobEffect effect = BuiltInRegistries.MOB_EFFECT.get(location);
 				
 				if(effect.equals(MobEffects.HARM) || effect.equals(MobEffects.HEAL))
 				{
@@ -357,7 +357,7 @@ public class ContentSummon extends Content
 					button1.active = false;
 				}
 				
-				if(this.potionPage == ForgeRegistries.MOB_EFFECTS.getKeys().size() - 3)
+				if(this.potionPage == BuiltInRegistries.MOB_EFFECT.keySet().size() - 3)
 				{
 					button2.active = false;
 				}
@@ -366,11 +366,11 @@ public class ContentSummon extends Content
 				{
 					EffectInstance tag = this.effects.getOrCreate(effect);
 					
-					container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 0, Config.getSliders().getMaxSummonPotionAmplifier(), 0, container, new LogicSliderSimple("amplifier" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable(effect.getDescriptionId()), value ->
+					container.addRenderableWidget(new GuiSlider(x + 118, y, 114, 20, 0, Config.getSliders().getMaxSummonPotionAmplifier(), 0, container, new LogicSliderSimple("amplifier" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable(effect.getDescriptionId()), value ->
 					{
 						tag.setAmplifier(value.byteValue());
 					})));
-					container.addRenderableWidget(new GuiSlider(x + 118, y + 24, 114, 20, 0, Config.getSliders().getMaxSummonPotionMinutes(), 0, container, new LogicSliderSimple("duration" + ForgeRegistries.MOB_EFFECTS.getKey(effect), Component.translatable("gui.worldhandler.potion.time.minutes"), value ->
+					container.addRenderableWidget(new GuiSlider(x + 118, y + 24, 114, 20, 0, Config.getSliders().getMaxSummonPotionMinutes(), 0, container, new LogicSliderSimple("duration" + BuiltInRegistries.MOB_EFFECT.getKey(effect), Component.translatable("gui.worldhandler.potion.time.minutes"), value ->
 					{
 						tag.setMinutes(value.intValue());
 					})));
@@ -449,12 +449,12 @@ public class ContentSummon extends Content
 		}
 		else if(EntityType.VILLAGER.equals(entity))
 		{
-			for(VillagerProfession profession : ForgeRegistries.VILLAGER_PROFESSIONS)
+			for(VillagerProfession profession : BuiltInRegistries.VILLAGER_PROFESSION)
 			{
 				if(StringUtils.equalsIgnoreCase(this.mob, profession.toString()))
 				{
 					CompoundTag villagerData = new CompoundTag();
-					villagerData.putString("profession", ForgeRegistries.VILLAGER_PROFESSIONS.getKey(profession).toString());
+					villagerData.putString("profession", BuiltInRegistries.VILLAGER_PROFESSION.getKey(profession).toString());
 					
 					this.mutable.setKey("VillagerData");
 					this.mutable.setTag(villagerData);
@@ -473,7 +473,7 @@ public class ContentSummon extends Content
 		else if(EntityType.CHICKEN.equals(entity) && StringUtils.containsIgnoreCase(this.mob, "Jockey") && !this.entity.hasPassengers())
 		{
 			ListTag list = new ListTag();
-			EntityTag zombie = new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.ZOMBIE));
+			EntityTag zombie = new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE));
 			
 			zombie.setIsBaby(true);
 			list.add(zombie.value());
@@ -484,7 +484,7 @@ public class ContentSummon extends Content
 		else if(EntityType.SPIDER.equals(entity) && StringUtils.containsIgnoreCase(this.mob, "Jockey") && !this.entity.hasPassengers())
 		{
 			ListTag list = new ListTag();
-			EntityTag skeleton = new EntityTag(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.SKELETON));
+			EntityTag skeleton = new EntityTag(BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.SKELETON));
 			
 			skeleton.setHandItem(0, Items.BOW);
 			list.add(skeleton.value());
@@ -503,7 +503,7 @@ public class ContentSummon extends Content
 	{
 		if(Page.POTIONS.equals(this.page))
 		{
-			guiGraphics.drawString(Minecraft.getInstance().font, (this.potionPage + 1) + "/" + (ForgeRegistries.MOB_EFFECTS.getKeys().size() - 2), x + 118, y - 11, Config.getSkin().getHeadlineColor(), false);
+			guiGraphics.drawString(Minecraft.getInstance().font, (this.potionPage + 1) + "/" + (BuiltInRegistries.MOB_EFFECT.keySet().size() - 2), x + 118, y - 11, Config.getSkin().getHeadlineColor(), false);
 		}
 		else if(Page.EQUIPMENT.equals(this.page))
 		{
@@ -529,8 +529,8 @@ public class ContentSummon extends Content
 	
 	private List<ResourceLocation> sortedEffects()
 	{
-		return ForgeRegistries.MOB_EFFECTS.getKeys().stream()
-			.sorted((a, b) -> I18n.get(ForgeRegistries.MOB_EFFECTS.getValue(a).getDescriptionId()).compareTo(I18n.get(ForgeRegistries.MOB_EFFECTS.getValue(b).getDescriptionId())))
+		return BuiltInRegistries.MOB_EFFECT.keySet().stream()
+			.sorted((a, b) -> I18n.get(BuiltInRegistries.MOB_EFFECT.get(a).getDescriptionId()).compareTo(I18n.get(BuiltInRegistries.MOB_EFFECT.get(b).getDescriptionId())))
 			.collect(Collectors.toList());
 	}
 	

--- a/src/main/java/exopandora/worldhandler/gui/content/impl/ContentWorldInfo.java
+++ b/src/main/java/exopandora/worldhandler/gui/content/impl/ContentWorldInfo.java
@@ -39,13 +39,13 @@ public class ContentWorldInfo extends Content
 		IntegratedServer server = Minecraft.getInstance().getSingleplayerServer();
 		
 		this.posXField = new GuiHintTextField(x + 118, y + 12, 114, 20);
-		this.posXField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " X: " + ContentWorldInfo.format(level, object -> object.getLevelData().getXSpawn()));
+		this.posXField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " X: " + ContentWorldInfo.format(level, object -> object.getLevelData().getSpawnPos().getX()));
 		
 		this.posYField = new GuiHintTextField(x + 118, y + 36, 114, 20);
-		this.posYField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " Y: " + ContentWorldInfo.format(level, object -> object.getLevelData().getYSpawn()));
+		this.posYField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " Y: " + ContentWorldInfo.format(level, object -> object.getLevelData().getSpawnPos().getY()));
 		
 		this.posZField = new GuiHintTextField(x + 118, y + 60, 114, 20);
-		this.posZField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " Z: " + ContentWorldInfo.format(level, object -> object.getLevelData().getZSpawn()));
+		this.posZField.setValue(I18n.get("gui.worldhandler.world_info.start.spawn") + " Z: " + ContentWorldInfo.format(level, object -> object.getLevelData().getSpawnPos().getZ()));
 		
 		this.worldField = new GuiHintTextField(x + 118, y + 12, 114, 20);
 		this.worldField.setValue(I18n.get("gui.worldhandler.world_info.world.name") + ": " + ContentWorldInfo.format(server, object -> object.getWorldData().getLevelName()));

--- a/src/main/java/exopandora/worldhandler/gui/widget/WidgetTabRenderer.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/WidgetTabRenderer.java
@@ -20,7 +20,7 @@ import net.minecraft.util.Mth;
 
 public class WidgetTabRenderer implements IContainerWidget
 {
-	private static final ResourceLocation TAB_TEXTURE = new ResourceLocation("textures/gui/demo_background.png");
+	private static final ResourceLocation TAB_TEXTURE = ResourceLocation.parse("textures/gui/demo_background.png");
 	private static final int SPACING = 2;
 	private static final int WEDGE_HEIGHT = 10;
 	

--- a/src/main/java/exopandora/worldhandler/gui/widget/button/GuiButtonBase.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/button/GuiButtonBase.java
@@ -19,9 +19,9 @@ public class GuiButtonBase extends AbstractButton
 {
 	protected static final WidgetSprites VANILLA_BUTTON_SPRITES = new WidgetSprites
 	(
-		new ResourceLocation(Main.MODID, "textures/skins/vanilla/button.png"),
-		new ResourceLocation(Main.MODID, "textures/skins/vanilla/button_disabled.png"),
-		new ResourceLocation(Main.MODID, "textures/skins/vanilla/button_highlighted.png")
+		ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/skins/vanilla/button.png"),
+		ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/skins/vanilla/button_disabled.png"),
+		ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/skins/vanilla/button_highlighted.png")
 	);
 	
 	private final ActionHandler actionHandler;

--- a/src/main/java/exopandora/worldhandler/gui/widget/button/GuiButtonPiano.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/button/GuiButtonPiano.java
@@ -16,7 +16,7 @@ import net.minecraft.sounds.SoundEvent;
 
 public class GuiButtonPiano extends GuiButtonBase
 {
-	private static final ResourceLocation NOTE = new ResourceLocation(Main.MODID, "textures/misc/note.png");
+	private static final ResourceLocation NOTE = ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/misc/note.png");
 	private final Type type;
 	private final SoundEvent sound;
 	private final float pitch;

--- a/src/main/java/exopandora/worldhandler/gui/widget/button/GuiHintTextField.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/button/GuiHintTextField.java
@@ -17,7 +17,7 @@ public class GuiHintTextField extends EditBox
 	
 	public GuiHintTextField(int x, int y, int width, int height, Component hint)
 	{
-		super(Minecraft.getInstance().font, x, y, width, height, null);
+		super(Minecraft.getInstance().font, x, y, width, height, Component.empty());
 		this.setMaxLength(Integer.MAX_VALUE);
 		this.hint = hint;
 	}
@@ -60,7 +60,7 @@ public class GuiHintTextField extends EditBox
 		}
 		else
 		{
-			this.setValue((String) null);
+			this.setValue("");
 		}
 	}
 }

--- a/src/main/java/exopandora/worldhandler/gui/widget/button/GuiSlider.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/button/GuiSlider.java
@@ -17,9 +17,9 @@ import net.minecraft.resources.ResourceLocation;
 
 public class GuiSlider extends GuiButtonBase
 {
-	private static final ResourceLocation SLIDER_SPRITE = new ResourceLocation("widget/slider");
-	private static final ResourceLocation SLIDER_HANDLE_SPRITE = new ResourceLocation("widget/slider_handle");
-	private static final ResourceLocation SLIDER_HANDLE_HIGHLIGHTED_SPRITE = new ResourceLocation("widget/slider_handle_highlighted");
+	private static final ResourceLocation SLIDER_SPRITE = ResourceLocation.parse("widget/slider");
+	private static final ResourceLocation SLIDER_HANDLE_SPRITE = ResourceLocation.parse("widget/slider_handle");
+	private static final ResourceLocation SLIDER_HANDLE_HIGHLIGHTED_SPRITE = ResourceLocation.parse("widget/slider_handle_highlighted");
 	private final Persistence persistence;
 	private final ILogicSlider logic;
 	private final Container container;

--- a/src/main/java/exopandora/worldhandler/gui/widget/button/LogicSliderAttribute.java
+++ b/src/main/java/exopandora/worldhandler/gui/widget/button/LogicSliderAttribute.java
@@ -5,13 +5,13 @@ import java.util.function.Consumer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class LogicSliderAttribute extends LogicSliderSimple
 {
 	public LogicSliderAttribute(Attribute attribute, MutableComponent text, Consumer<Integer> listener)
 	{
-		super(ForgeRegistries.ATTRIBUTES.getKey(attribute).toString(), text, listener);
+		super(BuiltInRegistries.ATTRIBUTE.getKey(attribute).toString(), text, listener);
 	}
 	
 	@Override

--- a/src/main/java/exopandora/worldhandler/usercontent/UsercontentLoader.java
+++ b/src/main/java/exopandora/worldhandler/usercontent/UsercontentLoader.java
@@ -171,7 +171,7 @@ public class UsercontentLoader
 	private static boolean isValidPathName(Path path)
 	{
 		String name = path.getFileName().toString();
-		boolean valid = ResourceLocation.isValidResourceLocation(name);
+		boolean valid = ResourceLocation.tryParse(name) != null;
 		
 		if(!valid)
 		{

--- a/src/main/java/exopandora/worldhandler/usercontent/factory/WidgetFactory.java
+++ b/src/main/java/exopandora/worldhandler/usercontent/factory/WidgetFactory.java
@@ -21,7 +21,7 @@ import exopandora.worldhandler.usercontent.model.JsonWidget;
 import exopandora.worldhandler.util.TextUtils;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class WidgetFactory extends AbstractWidgetFactory
 {
@@ -54,7 +54,7 @@ public class WidgetFactory extends AbstractWidgetFactory
 				widget.getLayout().getY() + y,
 				widget.getLayout().getWidth(),
 				widget.getLayout().getHeight(),
-				ForgeRegistries.ITEMS.getValue(new ResourceLocation(widget.getAttributes().getItem())),
+				BuiltInRegistries.ITEM.get(ResourceLocation.parse(widget.getAttributes().getItem())),
 				this.getActionHandlerFactory().createActionHandler(content, widget.getAction(), container::getPlayer)
 			);
 		}

--- a/src/main/java/exopandora/worldhandler/util/AdvancementHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/AdvancementHelper.java
@@ -1,48 +1,30 @@
 package exopandora.worldhandler.util;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementNode;
 import net.minecraft.client.Minecraft;
-import net.minecraft.server.ServerAdvancementManager;
-import net.minecraft.server.packs.PackResources;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.resources.PreparableReloadListener;
-import net.minecraft.server.packs.resources.ReloadableResourceManager;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.util.Unit;
-import net.minecraft.util.profiling.ProfilerFiller;
-import net.minecraft.world.level.storage.loot.LootDataManager;
-import net.minecraftforge.common.crafting.conditions.ICondition.IContext;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 
-public class AdvancementHelper implements PreparableReloadListener
+public class AdvancementHelper
 {
 	private static final AdvancementHelper INSTANCE = new AdvancementHelper();
-	private final ServerAdvancementManager manager = new ServerAdvancementManager(new LootDataManager(), IContext.EMPTY);
-	
-	@Override
-	public CompletableFuture<Void> reload(PreparationBarrier stage, ResourceManager resourceManager, ProfilerFiller preparationsProfiler, ProfilerFiller reloadProfiler, Executor backgroundExecutor, Executor gameExecutor)
-	{
-		return CompletableFuture.supplyAsync(() ->
-		{
-			ReloadableResourceManager serverResourceManager = new ReloadableResourceManager(PackType.SERVER_DATA);
-			serverResourceManager.registerReloadListener(this.manager);
-			return serverResourceManager;
-		}).thenCompose(stage::wait).thenAcceptAsync(serverResourceManager ->
-		{
-			List<PackResources> list = Minecraft.getInstance().getResourcePackRepository().getSelectedPacks().stream().map(Pack::open).collect(Collectors.toList());
-			serverResourceManager.createReload(backgroundExecutor, gameExecutor, CompletableFuture.completedFuture(Unit.INSTANCE), list);
-		});
-	}
 	
 	public Collection<AdvancementHolder> getAdvancements()
 	{
-		return this.manager.getAllAdvancements();
+		ClientPacketListener connection = Minecraft.getInstance().getConnection();
+		
+		if(connection == null)
+		{
+			return Collections.emptyList();
+		}
+		
+		return connection.getAdvancements().getTree().nodes().stream()
+				.map(AdvancementNode::holder)
+				.collect(Collectors.toList());
 	}
 	
 	public static AdvancementHelper getInstance()

--- a/src/main/java/exopandora/worldhandler/util/BlockPredicateParser.java
+++ b/src/main/java/exopandora/worldhandler/util/BlockPredicateParser.java
@@ -15,14 +15,14 @@ import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class BlockPredicateParser
 {
-	private static final ResourceLocation AIR_RESOURCE_LOCATION = ForgeRegistries.BLOCKS.getKey(Blocks.AIR);
+	private static final ResourceLocation AIR_RESOURCE_LOCATION = BuiltInRegistries.BLOCK.getKey(Blocks.AIR);
 	private final StringReader reader;
 	private final Map<String, String> vagueProperties = Maps.newHashMap();
-	private ResourceLocation block = new ResourceLocation("");
+	private ResourceLocation block = null;
 	@Nullable
 	private CompoundTag nbt;
 	private boolean isTag;
@@ -157,7 +157,7 @@ public class BlockPredicateParser
 	
 	public Optional<Block> getBlock()
 	{
-		Block block = ForgeRegistries.BLOCKS.getValue(this.block);
+		Block block = BuiltInRegistries.BLOCK.get(this.block);
 		
 		if(Blocks.AIR.equals(block) && !AIR_RESOURCE_LOCATION.equals(this.block))
 		{

--- a/src/main/java/exopandora/worldhandler/util/BlockPredicateParser.java
+++ b/src/main/java/exopandora/worldhandler/util/BlockPredicateParser.java
@@ -22,7 +22,7 @@ public class BlockPredicateParser
 	private static final ResourceLocation AIR_RESOURCE_LOCATION = BuiltInRegistries.BLOCK.getKey(Blocks.AIR);
 	private final StringReader reader;
 	private final Map<String, String> vagueProperties = Maps.newHashMap();
-	private ResourceLocation block = null;
+	private ResourceLocation block = AIR_RESOURCE_LOCATION;
 	@Nullable
 	private CompoundTag nbt;
 	private boolean isTag;

--- a/src/main/java/exopandora/worldhandler/util/ItemPredicateParser.java
+++ b/src/main/java/exopandora/worldhandler/util/ItemPredicateParser.java
@@ -19,9 +19,10 @@ import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ItemPredicateParser
 {
+	private static final ResourceLocation AIR_RESOURCE_LOCATION = BuiltInRegistries.ITEM.getKey(Items.AIR);
 	private static final SimpleCommandExceptionType ERROR_NO_TAGS_ALLOWED = new SimpleCommandExceptionType(Component.translatable("argument.item.tag.disallowed"));
 	private final StringReader reader;
-	private ResourceLocation item = null;
+	private ResourceLocation item = AIR_RESOURCE_LOCATION;
 	@Nullable
 	private CompoundTag nbt;
 	private boolean isTag;

--- a/src/main/java/exopandora/worldhandler/util/ItemPredicateParser.java
+++ b/src/main/java/exopandora/worldhandler/util/ItemPredicateParser.java
@@ -5,20 +5,23 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.commands.arguments.item.ItemParser;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagParser;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ItemPredicateParser
 {
+	private static final SimpleCommandExceptionType ERROR_NO_TAGS_ALLOWED = new SimpleCommandExceptionType(Component.translatable("argument.item.tag.disallowed"));
 	private final StringReader reader;
-	private ResourceLocation item = new ResourceLocation("");
+	private ResourceLocation item = null;
 	@Nullable
 	private CompoundTag nbt;
 	private boolean isTag;
@@ -39,7 +42,7 @@ public class ItemPredicateParser
 		{
 			if(!allowTags)
 			{
-				throw ItemParser.ERROR_NO_TAGS_ALLOWED.createWithContext(this.reader);
+				throw ERROR_NO_TAGS_ALLOWED.createWithContext(this.reader);
 			}
 			
 			this.readTag();
@@ -74,7 +77,7 @@ public class ItemPredicateParser
 	
 	public Optional<Item> getItem()
 	{
-		Item item = ForgeRegistries.ITEMS.getValue(this.item);
+		Item item = BuiltInRegistries.ITEM.get(this.item);
 		
 		if(Items.AIR.equals(item))
 		{

--- a/src/main/java/exopandora/worldhandler/util/NBTHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/NBTHelper.java
@@ -15,7 +15,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class NBTHelper
 {
@@ -62,7 +62,7 @@ public class NBTHelper
 		for(Item item : itemArray)
 		{
 			CompoundTag compound = new CompoundTag();
-			compound.putString("id", ForgeRegistries.ITEMS.getKey(item).toString());
+			compound.putString("id", BuiltInRegistries.ITEM.getKey(item).toString());
 			compound.putInt("Count", 1);
 			list.add(compound);
 		}

--- a/src/main/java/exopandora/worldhandler/util/RegistryHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/RegistryHelper.java
@@ -1,17 +1,63 @@
 package exopandora.worldhandler.util;
 
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import exopandora.worldhandler.Main;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.registries.RegisterEvent;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.neoforged.neoforge.registries.RegisterEvent;
 
 public class RegistryHelper
 {
 	public static <T> void register(RegisterEvent event, ResourceKey<Registry<T>> key, String location, Supplier<T> valueSupplier)
 	{
-		event.register(key, new ResourceLocation(Main.MODID, location), valueSupplier);
+		event.register(key, RegistryHelper.location(location), valueSupplier);
+	}
+	
+	public static ResourceLocation location(String location)
+	{
+		return ResourceLocation.fromNamespaceAndPath(Main.MODID, location);
+	}
+	
+	public static RegistryAccess registryAccess()
+	{
+		if(Minecraft.getInstance().level != null)
+		{
+			return Minecraft.getInstance().level.registryAccess();
+		}
+		
+		return RegistryAccess.EMPTY;
+	}
+	
+	public static Registry<Enchantment> enchantments()
+	{
+		return RegistryHelper.registryAccess().registryOrThrow(Registries.ENCHANTMENT);
+	}
+	
+	public static Collection<Enchantment> enchantmentValues()
+	{
+		return RegistryHelper.enchantments().stream().toList();
+	}
+	
+	public static Enchantment getEnchantment(ResourceLocation location)
+	{
+		return RegistryHelper.enchantments().get(location);
+	}
+	
+	public static ResourceLocation getEnchantmentKey(Enchantment enchantment)
+	{
+		return RegistryHelper.enchantments().getKey(enchantment);
+	}
+	
+	public static Component getEnchantmentDescription(Enchantment enchantment)
+	{
+		return enchantment.description();
 	}
 }

--- a/src/main/java/exopandora/worldhandler/util/ResourceHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/ResourceHelper.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 import exopandora.worldhandler.Main;
 import exopandora.worldhandler.config.Config;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraft.core.Registry;
 
 public class ResourceHelper
 {
@@ -20,13 +20,13 @@ public class ResourceHelper
 		return null;
 	}
 	
-	public static boolean isRegistered(ResourceLocation resource, IForgeRegistry<?> registry)
+	public static boolean isRegistered(ResourceLocation resource, Registry<?> registry)
 	{
 		return resource != null && registry != null && registry.containsKey(resource);
 	}
 	
 	@Nullable
-	public static ResourceLocation assertRegistered(ResourceLocation resource, IForgeRegistry<?> registry)
+	public static ResourceLocation assertRegistered(ResourceLocation resource, Registry<?> registry)
 	{
 		if(resource != null && ResourceHelper.isRegistered(resource, registry))
 		{
@@ -38,6 +38,6 @@ public class ResourceHelper
 	
 	public static ResourceLocation iconTexture()
 	{
-		return new ResourceLocation(Main.MODID, "textures/icons/icons_" + Config.getSkin().getIconSize().name() + ".png");
+		return ResourceLocation.fromNamespaceAndPath(Main.MODID, "textures/icons/icons_" + Config.getSkin().getIconSize().name() + ".png");
 	}
 }

--- a/src/main/java/exopandora/worldhandler/util/ScoreboardHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/ScoreboardHelper.java
@@ -14,7 +14,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.world.scores.Team.CollisionRule;
 import net.minecraft.world.scores.Team.Visibility;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 public class ScoreboardHelper
 {
@@ -44,7 +44,7 @@ public class ScoreboardHelper
 		
 		this.objectives.merge("minecraft", (parent, child) -> parent + "." + child);
 		
-		for(StatType<?> type : ForgeRegistries.STAT_TYPES)
+		for(StatType<?> type : BuiltInRegistries.STAT_TYPE)
 		{
 			if(!type.equals(Stats.CUSTOM))
 			{
@@ -55,7 +55,7 @@ public class ScoreboardHelper
 					entries.add(new Node(this.buildKey(key)));
 				}
 				
-				this.objectives.addNode(this.buildKey(ForgeRegistries.STAT_TYPES.getKey(type)), entries);
+				this.objectives.addNode(this.buildKey(BuiltInRegistries.STAT_TYPE.getKey(type)), entries);
 			}
 		}
 		

--- a/src/main/java/exopandora/worldhandler/util/TextUtils.java
+++ b/src/main/java/exopandora/worldhandler/util/TextUtils.java
@@ -13,6 +13,11 @@ public class TextUtils
 	public static final MutableComponent ARROW_LEFT_BOLD = Component.literal("<").withStyle(ChatFormatting.BOLD);
 	public static final MutableComponent ARROW_RIGHT_BOLD = Component.literal(">").withStyle(ChatFormatting.BOLD);
 	
+	public static String toJson(Component component)
+	{
+		return Component.Serializer.toJson(component, RegistryHelper.registryAccess());
+	}
+	
 	public static MutableComponent stripText(MutableComponent string, int maxWidth, Font font)
 	{
 		return TextUtils.stripText(string, Component.empty(), maxWidth, font);

--- a/src/main/java/exopandora/worldhandler/util/TranslationHelper.java
+++ b/src/main/java/exopandora/worldhandler/util/TranslationHelper.java
@@ -10,32 +10,29 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.block.Block;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 
 public class TranslationHelper
 {
-	private static final Map<IForgeRegistry<?>, Function<?, String>> FORGE = new HashMap<IForgeRegistry<?>, Function<?, String>>();
+	private static final Map<Registry<?>, Function<?, String>> FORGE = new HashMap<Registry<?>, Function<?, String>>();
 	
 	static
 	{
-		registerRegistry(ForgeRegistries.BLOCKS, Block::getDescriptionId);
-		registerRegistry(ForgeRegistries.ITEMS, Item::getDescriptionId);
-		registerRegistry(ForgeRegistries.MOB_EFFECTS, MobEffect::getDescriptionId);
-		registerRegistry(ForgeRegistries.BIOMES, biome -> ForgeRegistries.BIOMES.getKey(biome).toLanguageKey("biome"));
-		registerRegistry(ForgeRegistries.ENCHANTMENTS, Enchantment::getDescriptionId);
-		registerRegistry(ForgeRegistries.ENTITY_TYPES, EntityType::getDescriptionId);
-		registerRegistry(ForgeRegistries.STAT_TYPES, stat -> "stat." + stat.toString().replace(':', '.'));
-		registerRegistry(ForgeRegistries.VILLAGER_PROFESSIONS, profession ->
+		registerRegistry(BuiltInRegistries.BLOCK, Block::getDescriptionId);
+		registerRegistry(BuiltInRegistries.ITEM, Item::getDescriptionId);
+		registerRegistry(BuiltInRegistries.MOB_EFFECT, MobEffect::getDescriptionId);
+		registerRegistry(BuiltInRegistries.ENTITY_TYPE, EntityType::getDescriptionId);
+		registerRegistry(BuiltInRegistries.STAT_TYPE, stat -> "stat." + stat.toString().replace(':', '.'));
+		registerRegistry(BuiltInRegistries.VILLAGER_PROFESSION, profession ->
 		{
-			ResourceLocation profName = ForgeRegistries.VILLAGER_PROFESSIONS.getKey(profession);
+			ResourceLocation profName = BuiltInRegistries.VILLAGER_PROFESSION.getKey(profession);
 			return EntityType.VILLAGER.getDescriptionId() + '.' + (!"minecraft".equals(profName.getNamespace()) ? profName.getNamespace() + '.' : "") + profName.getPath();
 		});
 	}
 	
-	private static <T> void registerRegistry(IForgeRegistry<T> registry, Function<T, String> mapper)
+	private static <T> void registerRegistry(Registry<T> registry, Function<T, String> mapper)
 	{
 		FORGE.put(registry, mapper);
 	}
@@ -44,11 +41,16 @@ public class TranslationHelper
 	@SuppressWarnings("unchecked")
 	public static <T> String translate(ResourceLocation resource)
 	{
-		for(IForgeRegistry<?> registry : FORGE.keySet())
+		if(RegistryHelper.getEnchantment(resource) != null)
+		{
+			return RegistryHelper.getEnchantmentDescription(RegistryHelper.getEnchantment(resource)).getString();
+		}
+		
+		for(Registry<?> registry : FORGE.keySet())
 		{
 			if(registry.containsKey(resource))
 			{
-				return ((Function<T, String>) FORGE.get(registry)).apply((T) registry.getValue(resource));
+				return ((Function<T, String>) FORGE.get(registry)).apply((T) registry.get(resource));
 			}
 		}
 		

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,11 +1,11 @@
-public net.minecraft.commands.arguments.blocks.BlockInput f_114664_ # tag
-public net.minecraft.server.MinecraftServer f_129744_ # storageSource
-public net.minecraft.client.gui.screens.OptionsScreen m_96244_(Lnet/minecraft/server/packs/repository/PackRepository;)V # updatePackList
-public net.minecraft.commands.arguments.EntityAnchorArgument$Anchor f_90367_ # name
-public net.minecraft.commands.arguments.coordinates.LocalCoordinates m_119908_(Lcom/mojang/brigadier/StringReader;I)D # readDouble
-public net.minecraft.advancements.critereon.MinMaxBounds$Doubles <init>(Ljava/util/Optional;Ljava/util/Optional;)V # constructor
-public net.minecraft.advancements.critereon.MinMaxBounds$Ints <init>(Ljava/util/Optional;Ljava/util/Optional;)V # constructor
-public net.minecraft.network.chat.MutableComponent <init>(Lnet/minecraft/network/chat/ComponentContents;Ljava/util/List;Lnet/minecraft/network/chat/Style;)V # constructor
-public net.minecraft.commands.arguments.item.ItemParser f_120991_ # ERROR_NO_TAGS_ALLOWED
-public net.minecraft.world.level.storage.PrimaryLevelData f_78443_ # settings
-public net.minecraft.client.gui.components.AbstractWidget m_280138_(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIII)V # renderScrollingString
+public net.minecraft.commands.arguments.blocks.BlockInput tag
+public net.minecraft.server.MinecraftServer storageSource
+public net.minecraft.client.gui.screens.OptionsScreen updatePackList(Lnet/minecraft/server/packs/repository/PackRepository;)V
+public net.minecraft.commands.arguments.EntityAnchorArgument$Anchor name
+public net.minecraft.commands.arguments.coordinates.LocalCoordinates readDouble(Lcom/mojang/brigadier/StringReader;I)D
+public net.minecraft.advancements.critereon.MinMaxBounds$Doubles <init>(Ljava/util/Optional;Ljava/util/Optional;)V
+public net.minecraft.advancements.critereon.MinMaxBounds$Ints <init>(Ljava/util/Optional;Ljava/util/Optional;)V
+public net.minecraft.network.chat.MutableComponent <init>(Lnet/minecraft/network/chat/ComponentContents;Ljava/util/List;Lnet/minecraft/network/chat/Style;)V
+public net.minecraft.commands.arguments.item.ItemParser ERROR_NO_TAGS_ALLOWED
+public net.minecraft.world.level.storage.PrimaryLevelData settings
+public net.minecraft.client.gui.components.AbstractWidget renderScrollingString(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIII)V

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[49,)"
+loaderVersion="${loader_version_range}"
 updateJSONURL="https://raw.githubusercontent.com/Exopandora/worldhandler/master/version.json"
 issueTrackerURL="https://github.com/Exopandora/WorldHandler/issues"
 displayURL="https://minecraft.curseforge.com/projects/world-handler-command-gui"
@@ -11,13 +11,20 @@ license="GPL v3.0"
 
 [[mods]]
 	modId="worldhandler"
-	version="1.20.4-${version}"
+	version="1.21.1-${version}"
 	displayName="World Handler"
 	description="The World Handler provides a simple and easy to use graphical user interface for commands. It lets you create powerful and complex sub-commands alongside NBT-structures within seconds."
 
 [[dependencies.worldhandler]]
     modId="minecraft"
-    mandatory=true
-    versionRange="[1.20.3,)"
+    type="required"
+    versionRange="[1.21.1,1.21.2)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.worldhandler]]
+    modId="neoforge"
+    type="required"
+    versionRange="[21.1.225,)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -18,13 +18,13 @@ license="GPL v3.0"
 [[dependencies.worldhandler]]
     modId="minecraft"
     type="required"
-    versionRange="[1.21.1,1.21.2)"
+    versionRange="[1.21,1.21.2)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.worldhandler]]
     modId="neoforge"
     type="required"
-    versionRange="[21.1.225,)"
+    versionRange="[21.0.167,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Port WorldHandler to Minecraft 1.21.1 on NeoForge 21.1.225.

This migrates the build from ForgeGradle to NeoForge ModDevGradle, updates mod metadata, replaces Forge API usage with NeoForge equivalents, updates registry access for 1.21.1, and avoids a client-startup advancement reload that can hang large modpacks.

Validated with compileJava and full Gradle build.